### PR TITLE
Missing normalization in contour2centroid, compared to NEURON

### DIFF
--- a/morph_tool/converter.py
+++ b/morph_tool/converter.py
@@ -72,10 +72,12 @@ def make_convex(sides, rads):
             else:
                 idx[i] = False
         return idx
+
     for i_side in [0, 1]:
         ci = convex_idx(sides[i_side])
         sides[i_side] = sides[i_side][ci]
         rads[i_side] = rads[i_side][ci]
+
     return sides, rads
 
 
@@ -102,6 +104,7 @@ def contour2centroid(mean, points):
     idx = 3 - np.argmin(eigen_values) - np.argmax(eigen_values)
     minor = eigen_vectors[:, idx]
     minor[2] = 0
+    minor /= np.linalg.norm(minor)
 
     sides, rads = get_sides(points, major, minor)
     sides, rads = make_convex(sides, rads)


### PR DESCRIPTION
* https://github.com/neuronsimulator/nrn/blob/636e75c0c4b6eb7b97597b8224081e59183ee1c9/share/lib/hoc/import3d/import3d_gui.hoc#L1195
* Props to @asanin-epfl for tracking this down
* fixes #6