### PR TITLE
allow for creation of single point SWC somas for SONATA spec

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -123,7 +123,7 @@ Here are the possible cases for the soma conversion:
       The points of the new contour are the outline of the soma stack projected in the XY plane.
     - Soma three point cylinder:
       The soma becomes a sphere of same surface. The contour made by the circle of biggest section in the XY plane is sampled in 20 points written to disk.
-    - Soma sphere (soma represented by a single point represeting the center of a sphere and its radius): the contour made by the circle of biggest section in the XY plane is sampled in 20 points written to disk.
+    - Soma sphere (soma represented by a single point representing the center of a sphere and its radius): the contour made by the circle of biggest section in the XY plane is sampled in 20 points written to disk.
     - other:
       Not in SWC spec -> not supported
 
@@ -134,7 +134,7 @@ Here are the possible cases for the soma conversion:
 
     Depending on soma type:
 
-    - Soma single point sphere (soma represented by a single point represeting the center of a sphere and its radius): the contour made by the circle of biggest section in the XY plane is sampled in 20 points written to disk.
+    - Soma single point sphere (soma represented by a single point representing the center of a sphere and its radius): the contour made by the circle of biggest section in the XY plane is sampled in 20 points written to disk.
     - Soma contour: no conversion needed
     - other: not in H5/ASC specs -> not supported
 
@@ -145,7 +145,7 @@ Here are the possible cases for the soma conversion:
     - Soma single point sphere: no conversion needed
     - Soma contour: A soma stack of cylinder is generated.
       Each cylinder of the stack has its center and its axis along the principal direction of the contour.
-      The radius of each stack is choosen such that it minimises the distance between the cylinder and the contour.
+      The radius of each stack is chosen such that it minimises the distance between the cylinder and the contour.
     - other: not in H5/ASC specs -> not supported
 
 Example:
@@ -165,7 +165,7 @@ NRN simulator compartment coordinates
 The NRN simulator splits each section into chunks of equal length (equal only among a given section).
 These compartments do not really exist in the physical world but we can remap them to paths
 along the section. Each compartment can be associated to a path (a list of 3D points) such
-that the path and the compartment have the same pathlength.
+that the path and the compartment have the same path-length.
 
 The following function can be used to access the mapping NeuroM section ID -> list of paths for the section:
 

--- a/morph_tool/cli.py
+++ b/morph_tool/cli.py
@@ -58,7 +58,9 @@ def soma_surface(input_file, quiet):
               help='recenter the morphology based on the center of gravity of the soma')
 @click.option('--nrn-order', is_flag=True,
               help='whether to traverse the neuron in the NEURON fashion')
-def file(input_file, output_file, quiet, recenter, nrn_order):
+@click.option('--single-point-soma', is_flag=True,
+              help='For SWC files only')
+def file(input_file, output_file, quiet, recenter, nrn_order, single_point_soma):
     '''Convert a single morphology from/to the following formats: ASC, SWC, H5'''
     # pylint: disable=import-outside-toplevel
     from morph_tool import converter
@@ -66,7 +68,7 @@ def file(input_file, output_file, quiet, recenter, nrn_order):
     if quiet:
         L.setLevel(logging.WARNING)
 
-    converter.convert(input_file, output_file, recenter, nrn_order)
+    converter.convert(input_file, output_file, recenter, nrn_order, single_point_soma)
 
 
 @convert.command(short_help='Convert all morphologies in a folder')
@@ -79,7 +81,9 @@ def file(input_file, output_file, quiet, recenter, nrn_order):
               help='recenter the morphology based on the center of gravity of the soma')
 @click.option('--nrn-order', is_flag=True,
               help='whether to traverse the neuron in the NEURON fashion')
-def folder(input_dir, output_dir, extension, quiet, recenter, nrn_order):
+@click.option('--single-point-soma', is_flag=True,
+              help='For SWC files only')
+def folder(input_dir, output_dir, extension, quiet, recenter, nrn_order, single_point_soma):
     '''Convert all morphologies in the folder and its subfolders'''
     # pylint: disable=import-outside-toplevel
     from morph_tool import converter
@@ -91,7 +95,7 @@ def folder(input_dir, output_dir, extension, quiet, recenter, nrn_order):
     for path in iter_morphology_files(input_dir):
         try:
             converter.convert(path, Path(output_dir) / (path.stem + '.' + extension),
-                              recenter, nrn_order)
+                              recenter, nrn_order, single_point_soma)
         except:  # noqa, pylint: disable=bare-except
             failed_conversions.append(str(path))
 

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -3,7 +3,7 @@ import numpy as np
 import itertools as it
 import os
 
-from nose.tools import ok_
+from nose.tools import ok_, eq_
 
 import morphio
 from morph_tool import diff
@@ -46,3 +46,17 @@ def test_convert_recenter():
         simple = morphio.Morphology(simple)
         centered_morph = morphio.Morphology(outname)
         ok_(np.all((simple.points - centered_morph.points) == 1))
+
+def test_convert_swc_contour_to_sphere():
+    with setup_tempdir('test_convert_swc_contour_to_sphere') as tmp_dir:
+        # needs to have a complex contour soma
+        simple = os.path.join(PATH, 'tkb061126a4_ch0_cc2_h_zk_60x_1.asc')
+        outname = os.path.join(tmp_dir, 'test.swc')
+        convert(simple, outname, single_point_soma=True)
+
+        m = morphio.Morphology(outname)
+        eq_(1, len(m.soma.points))
+        eq_(1, len(m.soma.diameters))
+
+        #value dumped from NEURON: h.area(0.5, sec=icell.soma[0])
+        np.testing.assert_approx_equal(m.soma.surface, 476.0504050847511)

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -3,7 +3,7 @@ import numpy as np
 import itertools as it
 import os
 
-from nose.tools import ok_, eq_
+from nose.tools import ok_, assert_equal
 
 import morphio
 from morph_tool import diff
@@ -55,8 +55,8 @@ def test_convert_swc_contour_to_sphere():
         convert(simple, outname, single_point_soma=True)
 
         m = morphio.Morphology(outname)
-        eq_(1, len(m.soma.points))
-        eq_(1, len(m.soma.diameters))
+        assert_equal(1, len(m.soma.points))
+        assert_equal(1, len(m.soma.diameters))
 
         #value dumped from NEURON: h.area(0.5, sec=icell.soma[0])
         np.testing.assert_approx_equal(m.soma.surface, 476.0504050847511)


### PR DESCRIPTION
- formats that use a contour can be converted to have a spherical soma in SWC, as the SONATA spec requires.