### PR TITLE
multiple point to isec converter

### DIFF
--- a/morph_tool/nrnhines.py
+++ b/morph_tool/nrnhines.py
@@ -284,11 +284,11 @@ def isolate(func):
     Example:
 
         def _to_be_isolated(morphology_path, point):
-            cell = tested.get_NRN_cell(morphology_path)
-            return tested.point_to_section_end(cell.icell.all, point)
+            cell = nrnhines.get_NRN_cell(morphology_path)
+            return nrnhines.point_to_section_end(cell.icell.all, point)
 
         def _isolated(morph_data):
-            return tested.isolate(_to_be_isolated)(*morph_data)
+            return nrnhines.isolate(_to_be_isolated)(*morph_data)
 
         with nrnhines.NestedPool(processes=n_workers) as pool:
             result = pool.imap_unordered(_isolated, data)

--- a/morph_tool/nrnhines.py
+++ b/morph_tool/nrnhines.py
@@ -332,7 +332,7 @@ def convert_points_to_isecs(morphology_path,
         isections_file (str): patht to a json/yaml file to store isections data
         section_types (str): NEURON types of isection to consider
         n_workers (int): number of workers for multiprocessing"""
-    morphologies = Path(morphology_path).glob("**/*.asc")
+    morphologies = iter_morphology_files(morphology_path, recursive=True, extensions=('asc', 'swc'))
     with open(points_file, "rb") as yaml_file:
         points = yaml.safe_load(yaml_file)
 

--- a/morph_tool/nrnhines.py
+++ b/morph_tool/nrnhines.py
@@ -1,21 +1,26 @@
 """Utils related to the NRN simulator"""
+import json
 import logging
+import multiprocessing
+import multiprocessing.pool
+from functools import partial
 from pathlib import Path
 from typing import List, Sequence, Union
 
 import bluepyopt.ephys as ephys
 import neuron
 import numpy as np
+import yaml
 from neurom import COLS, NeuriteType, iter_sections, load_neuron
 from neurom.core import NeuriteIter
 from numpy.testing import assert_almost_equal
+from tqdm import tqdm
 
 L = logging.getLogger('morph_tool')
 
 
 def get_NRN_cell(filename: Path):
     """Returns a NRN cell"""
-
     m = ephys.morphologies.NrnFileMorphology(str(filename))
     sim = ephys.simulators.NrnSimulator()
     cell = ephys.models.CellModel('test', morph=m, mechs=[])
@@ -265,3 +270,91 @@ def point_to_section_end(sections: Sequence[neuron.nrn.Section],  # pylint: disa
         if np.isclose(point, last_section_point, atol=atol, rtol=rtol).all():
             return index
     return None
+
+
+class NoDaemonProcess(multiprocessing.Process):
+    """Class that represents a non-daemon process"""
+
+    def _get_daemon(self):  # pylint: disable=R0201
+        """Get daemon flag"""
+        return False
+
+    def _set_daemon(self, value):
+        """Set daemon flag"""
+
+    daemon = property(_get_daemon, _set_daemon)
+
+
+class NestedPool(multiprocessing.pool.Pool):  # pylint: disable=abstract-method
+    """Class that represents a MultiProcessing nested pool"""
+
+    Process = NoDaemonProcess
+
+
+def isolate(func):
+    """Isolate a generic function for independent NEURON instances.
+
+    Note: it does not work as decorator.
+
+    Args:
+        func (function): function to isolate"""
+    def func_isolated(*args, **kwargs):
+        with NestedPool(1, maxtasksperchild=1) as pool:
+            return pool.apply(func, args, kwargs)
+    return func_isolated
+
+
+def convert_point_to_isec(morphology_path, point, section_type="apical"):
+    """Convert a point position to NEURON section index and return cell name and id.
+
+    Args:
+        morphology_path (Path): path to morphology
+        point (list/ndarray): 3d point
+    """
+    cell = get_NRN_cell(morphology_path)
+    point = point_to_section_end(getattr(cell.icell, section_type), point)
+    return morphology_path.stem, point
+
+
+def convert_point_to_isec_isolated(morph_data, section_type="apical"):
+    """Serves as a decorator to isolate convert_point_to_isc, but work with multiprocessing."""
+    return isolate(convert_point_to_isec)(*morph_data, section_type=section_type)
+
+
+def convert_points_to_isecs(morphology_path,
+                            points_file, isections_file,
+                            section_type='all', n_workers=1):
+    """Convert 3d positions to NEURON isections and save to json/yaml file.
+
+    Args:
+        morphology_path (str): path to the morphologies
+        points_file (str): path to a json/yaml file with points data
+        isections_file (str): patht to a json/yaml file to store isections data
+        section_types (str): NEURON types of isection to consider
+        n_workers (int): number of workers for multiprocessing"""
+    morphologies = Path(morphology_path).glob("**/*.asc")
+    with open(points_file, "rb") as yaml_file:
+        points = yaml.safe_load(yaml_file)
+
+    points_to_convert = {
+        morphology: points[morphology.stem]
+        for morphology in morphologies
+        if morphology.stem in points
+        if points[morphology.stem] is not None
+    }
+
+    with NestedPool(processes=n_workers) as pool:
+        isections = {
+            cell_name: isec
+            for cell_name, isec in tqdm(  # pylint: disable=unnecessary-comprehension
+                pool.imap_unordered(partial(convert_point_to_isec_isolated,
+                                            section_type=section_type),
+                                    points_to_convert.items()),
+                total=len(points_to_convert),
+            )
+        }
+
+    if Path(isections_file).suffix == ".json":
+        json.dump(isections, open(isections_file, "w"), indent=4)
+    if Path(isections_file).suffix == ".yaml":
+        yaml.dump(isections, open(isections_file, "w"))

--- a/morph_tool/nrnhines.py
+++ b/morph_tool/nrnhines.py
@@ -344,15 +344,11 @@ def convert_points_to_isecs(morphology_path,
     }
 
     with NestedPool(processes=n_workers) as pool:
-        isections = {
-            cell_name: isec
-            for cell_name, isec in tqdm(  # pylint: disable=unnecessary-comprehension
-                pool.imap_unordered(partial(convert_point_to_isec_isolated,
+        isections = dict(tqdm(pool.imap_unordered(partial(convert_point_to_isec_isolated,
                                             section_type=section_type),
                                     points_to_convert.items()),
                 total=len(points_to_convert),
-            )
-        }
+            ))
 
     if Path(isections_file).suffix == ".json":
         json.dump(isections, open(isections_file, "w"), indent=4)

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -3,16 +3,16 @@ import nose.tools as nt
 import mock
 from mock import patch
 
-import morph_tool.loader as test_module
+import morph_tool.loader as tested
 
 
 def test_ensure_startswith_point():
     nt.assert_equal(
-        test_module._ensure_startswith_point(".ext"),
+        tested._ensure_startswith_point(".ext"),
         ".ext"
     )
     nt.assert_equal(
-        test_module._ensure_startswith_point("ext"),
+        tested._ensure_startswith_point("ext"),
         ".ext"
     )
 
@@ -20,7 +20,7 @@ def test_ensure_startswith_point():
 @patch('morphio.Morphology')
 def test_loader(f_mock):
     f_mock.configure_mock(side_effect=lambda *args: object())
-    loader = test_module.MorphLoader('/dir', file_ext='abc', cache_size=1)
+    loader = tested.MorphLoader('/dir', file_ext='abc', cache_size=1)
     morph1 = loader.get('test')
     # should get cached object now
     nt.assert_is(

--- a/tests/test_nrnhines.py
+++ b/tests/test_nrnhines.py
@@ -2,7 +2,8 @@ from pathlib import Path
 import numpy as np
 from numpy.testing import assert_array_almost_equal, assert_equal
 
-import morph_tool.nrnhines as test_module
+import morph_tool.nrnhines as tested
+from multiprocessing.pool import Pool
 
 DATA = Path(__file__).parent / 'data'
 SIMPLE = DATA / 'simple2.asc'
@@ -13,7 +14,7 @@ def test_interpolate_compartments():
                        [1, 0, 0],
                        [1, 2, 0],
                        [2, 2, 0]])
-    paths = test_module._compartment_paths(points, 3)
+    paths = tested._compartment_paths(points, 3)
     assert_equal(len(paths), 3)
 
     assert_array_almost_equal(paths[0],
@@ -32,7 +33,7 @@ def test_interpolate_compartments():
 
 
 def test_NeuroM_section_to_NRN_compartment_paths():
-    mapping = test_module.NeuroM_section_to_NRN_compartment_paths(SIMPLE)
+    mapping = tested.NeuroM_section_to_NRN_compartment_paths(SIMPLE)
 
     assert_array_almost_equal(mapping[1], [[[0., 0., 0.],
                                             [0., 5., 0.]]])
@@ -42,13 +43,40 @@ def test_NeuroM_section_to_NRN_compartment_paths():
 
 
 def test_point_to_section_end():
-    cell = test_module.get_NRN_cell(SIMPLE)
-    assert_equal(test_module.point_to_section_end(cell.icell.all, [-8, 10, 0]),
+    cell = tested.get_NRN_cell(SIMPLE)
+    assert_equal(tested.point_to_section_end(cell.icell.all, [-8, 10, 0]),
                  6)
 
-    assert_equal(test_module.point_to_section_end(cell.icell.all, [-8, 10, 2]),
+    assert_equal(tested.point_to_section_end(cell.icell.all, [-8, 10, 2]),
                  None)
 
-    assert_equal(test_module.point_to_section_end(cell.icell.all, [-8, 10, 2],
-                                                  atol=10),
+    assert_equal(tested.point_to_section_end(cell.icell.all, [-8, 10, 2],
+                                             atol=10),
                  3)
+
+
+def _to_be_isolated(morphology_path, point):
+    """Convert a point position to NEURON section index and return cell name and id.
+
+    Args:
+        morphology_path (Path): path to morphology
+        point (list/ndarray): 3d point
+    """
+    cell = tested.get_NRN_cell(morphology_path)
+    return tested.point_to_section_end(cell.icell.all, point)
+
+
+def _isolated(morph_data):
+    """Serves as a decorator to isolate convert_point_to_isc, but work with multiprocessing."""
+    return tested.isolate(_to_be_isolated)(*morph_data)
+
+
+def test_isolate():
+    n_workers = 4
+    with tested.NestedPool(processes=n_workers) as pool:
+        result = list(pool.imap_unordered(_isolated,
+                                          [(SIMPLE, [-8, 10, 0]),
+                                           (SIMPLE, [-8, 10, 0]),
+                                           (SIMPLE, [-8, 10, 0]),
+                                           (SIMPLE, [-8, 10, 0]), ]))
+    assert_equal(result, [6] * 4)

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -7,7 +7,7 @@ import numpy.testing as npt
 
 import morphio
 
-import morph_tool.transform as test_module
+import morph_tool.transform as tested
 
 
 TEST_DIR = os.path.dirname(os.path.abspath(__file__))
@@ -38,7 +38,7 @@ class TestTransform:
 
     def test_translate_1(self):
         """ Translate whole morphology inplace. """
-        test_module.translate(self.morph, [1., 2., 3.])
+        tested.translate(self.morph, [1., 2., 3.])
         npt.assert_almost_equal(
             self.morph.soma.points[0],
             [1., 2., 3.]
@@ -55,7 +55,7 @@ class TestTransform:
     def test_translate_2(self):
         """ Translate axon inplace. """
         axon = self.morph.root_sections[1]
-        test_module.translate(axon, [1., 2., 3.])
+        tested.translate(axon, [1., 2., 3.])
         npt.assert_almost_equal(
             axon.children[1].points[-1],
             [-4., -2., 3.]
@@ -75,13 +75,13 @@ class TestTransform:
         """ Check translation vector. """
         nt.assert_raises(
             ValueError,
-            test_module.translate, self.morph, np.identity(4)
+            tested.translate, self.morph, np.identity(4)
         )
 
     def test_rotate_1(self):
         """ Rotate whole morphology inplace. """
         A = [[0, 1, 0], [-1, 0, 0], [0, 0, 1]]  # rotate around Z by 90 degrees
-        test_module.rotate(self.morph, A)
+        tested.rotate(self.morph, A)
         npt.assert_almost_equal(
             self.morph.soma.points[0],
             [0., 0., 0.]
@@ -99,7 +99,7 @@ class TestTransform:
         """ Rotate whole morphology inplace. """
         A = [[0, 1, 0], [-1, 0, 0], [0, 0, 1]]  # rotate around Z by 90 degrees
 
-        test_module.rotate(self.morph, A, origin=(1, 1, 1))
+        tested.rotate(self.morph, A, origin=(1, 1, 1))
         npt.assert_almost_equal(
             self.morph.soma.points[0],
             [0., 2., 0.]
@@ -118,14 +118,14 @@ class TestTransform:
         """ Check rotation matrix shape. """
         nt.assert_raises(
             ValueError,
-            test_module.rotate, self.morph, np.identity(4)
+            tested.rotate, self.morph, np.identity(4)
         )
 
     def test_transform_1(self):
         """ Transform whole morphology inplace. """
         # scale Y coordinate by 3 + shift by (-1, -2, -3)
         A = [[1, 0, 0, -1], [0, 3, 0, -2], [0, 0, 1, -3], [0, 0, 0, 1]]
-        test_module.transform(self.morph, A)
+        tested.transform(self.morph, A)
         npt.assert_almost_equal(
             self.morph.soma.points[0],
             [-1., -2., -3.]
@@ -143,13 +143,13 @@ class TestTransform:
         """ Check transform matrix shape. """
         nt.assert_raises(
             ValueError,
-            test_module.transform, self.morph, np.identity(3)
+            tested.transform, self.morph, np.identity(3)
         )
 
 
     def test_align(self):
         section = self.morph.section(0)
-        test_module.align(section, [-1, -1, 0])
+        tested.align(section, [-1, -1, 0])
 
         npt.assert_almost_equal(section.points,
                                 [[0., 0., 0.], [-3.535534, -3.535534, 0.]])
@@ -161,12 +161,12 @@ class TestTransform:
 
     def test_align_already_aligned(self):
         section = self.morph.section(1)
-        test_module.align(section, [-1, 0, 0])
+        tested.align(section, [-1, 0, 0])
 
         npt.assert_almost_equal(section.points, [[0., 5., 0.], [-5, 5, 0]])
 
     def test_align_pi_angle(self):
         section = self.morph.section(1)
-        test_module.align(section, [+1, 0, 0])
+        tested.align(section, [+1, 0, 0])
 
         npt.assert_almost_equal(section.points, [[0., 5., 0.], [+5, 5, 0]])


### PR DESCRIPTION
This is a proposal PR to allow for converting a list of 3d points to a list of neuron isections with multiprocessing. This can be used to process a large number of morphologies, and requires each computation to be isolated to prevent NEURON clashes with itself.

Things to do/discuss:
- is this the correct place?
- shall we add an app?
- it needs some tests
- it may assume too much from the file structure, etc... for a generic user
- the isolating functions should be used for any NEURON based computations in parallel, so it may serve for other functions in the package. It may be worth moving these (along with NestedPool) to a utils.py?