### PR TITLE
bypassing lru_cache if cache_size=0 in MorphLoader

### DIFF
--- a/morph_tool/cli.py
+++ b/morph_tool/cli.py
@@ -46,10 +46,11 @@ def soma_surface(input_file, quiet):
 
     try:
         click.echo('Soma surface: {}'.format(get_NEURON_surface(input_file)))
-    except ImportError:
+    except ImportError as e:
         raise ImportError('''the NEURON module is not installed.
         - if you are on the cluster, you can try: module load nix/hpc/neuron
-        - otherwise, get it here: https://github.com/neuronsimulator/nrn and compile it...''')
+        - otherwise, get it here: https://github.com/neuronsimulator/nrn and compile it...'''
+                          ) from e
 
 
 @convert.command(short_help='Convert a single morphology')

--- a/morph_tool/converter.py
+++ b/morph_tool/converter.py
@@ -256,9 +256,9 @@ def convert(input_file, outputfile, recenter=False, nrn_order=False, single_poin
                      MorphologyVersion.MORPHOLOGY_VERSION_H5_1_1: from_h5_or_asc,
                      MorphologyVersion.MORPHOLOGY_VERSION_H5_2: from_h5_or_asc
                      }[neuron.version]
-    except KeyError:
+    except KeyError as e:
         raise Exception(
-            'No converter for morphology type: {}'.format(neuron.version))
+            'No converter for morphology type: {}'.format(neuron.version)) from e
 
     logger.info('Original soma type: %s', neuron.soma_type)
     new = converter(neuron, output_ext)

--- a/morph_tool/dendrogram.py
+++ b/morph_tool/dendrogram.py
@@ -19,7 +19,7 @@ class SynDendrogram(Dendrogram):
     """Dendrogram that keeps track of ``neurom_section.id`` that was used to create it."""
 
     def __init__(self, neurom_section):
-        super(SynDendrogram, self).__init__(neurom_section)
+        super().__init__(neurom_section)
         if isinstance(neurom_section, Neuron):
             self.section_id = -1
             self.children = [

--- a/morph_tool/loader.py
+++ b/morph_tool/loader.py
@@ -27,15 +27,15 @@ class MorphLoader(object):
         base_dir: path to directory with morphology files
         file_ext: file extension to look for
         cache_size: size of LRU cache (if `None`, the cache can grow without bound,
-            if 1, no lru_cache is used)
+            if 0, no lru_cache is used)
     """
     def __init__(self, base_dir, file_ext, cache_size=None):
         self.base_dir = base_dir
         self.file_ext = _ensure_startswith_point(file_ext)
-        if cache_size > 1:
-            self.get = lru_cache(maxsize=cache_size)(self._get)
-        else:
+        if cache_size == 0:
             self.get = self._get
+        else:
+            self.get = lru_cache(maxsize=cache_size)(self._get)
 
     def _get(self, name, options=None):
         filepath = os.path.join(self.base_dir, name + self.file_ext)

--- a/morph_tool/loader.py
+++ b/morph_tool/loader.py
@@ -26,12 +26,16 @@ class MorphLoader(object):
     Args:
         base_dir: path to directory with morphology files
         file_ext: file extension to look for
-        cache_size: size of LRU cache (if `None`, the cache can grow without bound)
+        cache_size: size of LRU cache (if `None`, the cache can grow without bound,
+            if 1, no lru_cache is used)
     """
     def __init__(self, base_dir, file_ext, cache_size=None):
         self.base_dir = base_dir
         self.file_ext = _ensure_startswith_point(file_ext)
-        self.get = lru_cache(maxsize=cache_size)(self._get)
+        if cache_size > 1:
+            self.get = lru_cache(maxsize=cache_size)(self._get)
+        else:
+            self.get = self._get
 
     def _get(self, name, options=None):
         filepath = os.path.join(self.base_dir, name + self.file_ext)

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -2,6 +2,7 @@ import nose.tools as nt
 
 import mock
 from mock import patch
+from nose.tools import assert_equal
 
 import morph_tool.loader as tested
 
@@ -20,7 +21,7 @@ def test_ensure_startswith_point():
 @patch('morphio.Morphology')
 def test_loader(f_mock):
     f_mock.configure_mock(side_effect=lambda *args: object())
-    loader = tested.MorphLoader('/dir', file_ext='abc', cache_size=2)
+    loader = tested.MorphLoader('/dir', file_ext='abc', cache_size=1)
     morph1 = loader.get('test')
     # should get cached object now
     nt.assert_is(
@@ -32,9 +33,7 @@ def test_loader(f_mock):
         loader.get('test', options=42),
         morph1
     )
-
     # first cached object was evicted from the cache
-    loader.get('test', options=1)
     nt.assert_is_not(
         loader.get('test'),
         morph1
@@ -44,3 +43,11 @@ def test_loader(f_mock):
         mock.call('/dir/test.abc', 42),
         mock.call('/dir/test.abc'),
     ])
+
+@patch('morphio.Morphology')
+def test_loader_no_cache(f_mock):
+    f_mock.configure_mock(side_effect=lambda *args: object())
+    loader = tested.MorphLoader('/dir', file_ext='abc', cache_size=0)
+    loader.get('test')
+    loader.get('test')
+    assert_equal(f_mock.call_count, 2)

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -32,7 +32,13 @@ def test_loader(f_mock):
         loader.get('test', options=42),
         morph1
     )
+
+    nt.assert_is(
+        loader.get('test'),
+        morph1
+    )
     # first cached object was evicted from the cache
+    loader.get('test', options=1)
     nt.assert_is_not(
         loader.get('test'),
         morph1

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -20,7 +20,7 @@ def test_ensure_startswith_point():
 @patch('morphio.Morphology')
 def test_loader(f_mock):
     f_mock.configure_mock(side_effect=lambda *args: object())
-    loader = tested.MorphLoader('/dir', file_ext='abc', cache_size=1)
+    loader = tested.MorphLoader('/dir', file_ext='abc', cache_size=2)
     morph1 = loader.get('test')
     # should get cached object now
     nt.assert_is(

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -33,10 +33,6 @@ def test_loader(f_mock):
         morph1
     )
 
-    nt.assert_is(
-        loader.get('test'),
-        morph1
-    )
     # first cached object was evicted from the cache
     loader.get('test', options=1)
     nt.assert_is_not(


### PR DESCRIPTION
This is to allow for a complete bypassing of lru_cache from outside (in particular, placement-algorithm without mpi)