### PR TITLE
Update neurondb_dataframe to handle empty <repair> tag

### DIFF
--- a/morph_tool/graft.py
+++ b/morph_tool/graft.py
@@ -28,7 +28,7 @@ def find_axon(axon_or_donor_axon):
         raise NoAxonException('No axon found!')
 
     if len(axons) > 1:
-       raise TooManyAxonsException('Too many axons found!')
+        raise TooManyAxonsException('Too many axons found!')
 
     return axons[0]
 

--- a/morph_tool/graft.py
+++ b/morph_tool/graft.py
@@ -27,8 +27,8 @@ def find_axon(axon_or_donor_axon):
     if not axons:
         raise NoAxonException('No axon found!')
 
-    if len(axons) > 1:
-        raise TooManyAxonsException('Too many axons found!')
+    #if len(axons) > 1:
+    #    raise TooManyAxonsException('Too many axons found!')
 
     return axons[0]
 

--- a/morph_tool/graft.py
+++ b/morph_tool/graft.py
@@ -27,8 +27,8 @@ def find_axon(axon_or_donor_axon):
     if not axons:
         raise NoAxonException('No axon found!')
 
-    #if len(axons) > 1:
-    #    raise TooManyAxonsException('Too many axons found!')
+    if len(axons) > 1:
+       raise TooManyAxonsException('Too many axons found!')
 
     return axons[0]
 

--- a/morph_tool/utils.py
+++ b/morph_tool/utils.py
@@ -73,21 +73,17 @@ def neurondb_dataframe(neurondb: Path, morphology_dir: Optional[Path] = None) ->
 
         rows = list()
         for morph in _ensure_list(neuronDB["neurondb"]["listing"]["morphology"]):
-            row = (morph["name"],
-                   morph["layer"],
-                   morph["mtype"] + (":" + morph["msubtype"] if morph["msubtype"] else ""),
-                   )
-            columns = ['name', 'layer', 'mtype']
-            if 'repair' in morph:
-                assert morph["repair"]["use_axon"] in {'true', 'false', 'True', 'False', None}
-                # According to Eilif, an empty use_axon (corresponding to a null in the database)
-                # means that the axon is supposed to be used
-                row += (morph["repair"]["use_axon"] in {'true', 'True', None},)
-                columns += ['use_axon']
-            rows.append(row)
+            use_axon = morph.get("repair", {}).get("use_axon")
+            assert use_axon in {'true', 'false', 'True', 'False', None}
+            rows.append(
+                (morph["name"],
+                 morph["layer"],
+                 morph["mtype"] + (":" + morph["msubtype"] if morph["msubtype"] else ""),
+                 # According to Eilif, an empty use_axon (corresponding to a null in the database)
+                 # means that the axon is supposed to be used
+                 (use_axon in {'true', 'True', None})))
 
-        df = pd.DataFrame(data=rows, columns=columns)
-
+        df = pd.DataFrame(data=rows, columns=['name', 'layer', 'mtype', 'use_axon'])
     else:
         raise ValueError(f'Unrecognized extension for neurondb file: {neurondb}')
 

--- a/morph_tool/utils.py
+++ b/morph_tool/utils.py
@@ -73,16 +73,20 @@ def neurondb_dataframe(neurondb: Path, morphology_dir: Optional[Path] = None) ->
 
         rows = list()
         for morph in _ensure_list(neuronDB["neurondb"]["listing"]["morphology"]):
-            assert morph["repair"]["use_axon"] in {'true', 'false', 'True', 'False', None}
-            rows.append(
-                (morph["name"],
-                 morph["layer"],
-                 morph["mtype"] + (":" + morph["msubtype"] if morph["msubtype"] else ""),
-                 # According to Eilif, an empty use_axon (corresponding to a null in the database)
-                 # means that the axon is supposed to be used
-                 (morph["repair"]["use_axon"] in {'true', 'True', None})))
+            row = (morph["name"],
+                   morph["layer"],
+                   morph["mtype"] + (":" + morph["msubtype"] if morph["msubtype"] else ""),
+                   )
+            columns = ['name', 'layer', 'mtype']
+            if 'repair' in morph:
+                assert morph["repair"]["use_axon"] in {'true', 'false', 'True', 'False', None}
+                # According to Eilif, an empty use_axon (corresponding to a null in the database)
+                # means that the axon is supposed to be used
+                row += (morph["repair"]["use_axon"] in {'true', 'True', None},)
+                columns += ['use_axon']
+            rows.append(row)
 
-        df = pd.DataFrame(data=rows, columns=['name', 'layer', 'mtype', 'use_axon'])
+        df = pd.DataFrame(data=rows, columns=columns)
 
     else:
         raise ValueError(f'Unrecognized extension for neurondb file: {neurondb}')

--- a/tests/data/neurondb-no-repair.xml
+++ b/tests/data/neurondb-no-repair.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<neurondb>
+  <meta>
+    <readme>
+        same as neurondb.xml but without the "repair" element
+    </readme>
+  </meta>
+  <listing>
+    <morphology>
+      <name>C270106A</name>
+      <mtype>L1_DAC</mtype>
+      <msubtype></msubtype>
+      <layer>1</layer>
+    </morphology>
+    <morphology>
+      <name>C270106C</name>
+      <mtype>L1_DAC</mtype>
+      <msubtype></msubtype>
+      <layer>1</layer>
+    </morphology>
+    <morphology>
+        <name>a_neuron</name>
+        <mtype>an_mtype</mtype>
+        <msubtype>a_subtype</msubtype>
+        <layer>1</layer>
+    </morphology>
+    <morphology>
+        <name>a_2nd_neuron</name>
+        <mtype>an_mtype</mtype>
+        <msubtype>a_subtype</msubtype>
+        <layer>1</layer>
+    </morphology>
+  </listing>
+</neurondb>

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -73,6 +73,22 @@ def test_neurondb_dataframe():
     assert_raises(ValueError, tested.neurondb_dataframe, DATA / 'neurondb.wrongext')
 
 
+def test_neurondb_dataframe_no_repair():
+    df = tested.neurondb_dataframe(DATA / 'neurondb-no-repair.xml')
+    expected = pd.DataFrame(data=[['C270106A', '1', 'L1_DAC', True],
+                                  ['C270106C', '1', 'L1_DAC', True],
+
+                                  # This time (cf test_neurondb_dataframe), use_axon is True
+                                  ['a_neuron', '1', 'an_mtype:a_subtype', True],
+
+                                  ['a_2nd_neuron', '1', 'an_mtype:a_subtype', True],
+                                  ],
+                            columns=['name', 'layer', 'mtype', 'use_axon'])
+
+    assert_frame_equal(df, expected)
+
+    assert_raises(ValueError, tested.neurondb_dataframe, DATA / 'neurondb.wrongext')
+
 
 def mock_path_content(content):
     class MockPathContent:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -87,8 +87,6 @@ def test_neurondb_dataframe_no_repair():
 
     assert_frame_equal(df, expected)
 
-    assert_raises(ValueError, tested.neurondb_dataframe, DATA / 'neurondb.wrongext')
-
 
 def mock_path_content(content):
     class MockPathContent:


### PR DESCRIPTION
When reading an XML neurondb, use_axon will default to True
if the <repair> tag is missing.

Cf the famous quote:
"According to Eilif, an empty use_axon (corresponding to a null in the database)
means that the axon is supposed to be used"
