### PR TITLE
Fix scipy breaking change in 1.6.0

### DIFF
--- a/morph_tool/transform.py
+++ b/morph_tool/transform.py
@@ -95,6 +95,6 @@ def align(section, direction):
     else:
         axis = np.cross(section_dir, direction)
     axis /= np.linalg.norm(axis)
-    matrix = Rotation.from_rotvec(alpha * axis).as_dcm()
+    matrix = Rotation.from_rotvec(alpha * axis).as_matrix()
 
     rotate(section, matrix, origin=section.points[0])


### PR DESCRIPTION
'scipy.spatial.transform.rotation.Rotation' object has no attribute 'as_dcm'

'as_dcm' is actually the same as 'as_matrix'

https://docs.scipy.org/doc/scipy-1.4.0/reference/generated/scipy.spatial.transform.Rotation.as_dcm.html
