### PR TITLE
📝 Improve morph-tool diff

### DIFF
--- a/morph_tool/cli.py
+++ b/morph_tool/cli.py
@@ -120,8 +120,12 @@ def folder(input_dir, output_dir, extension, quiet, recenter, nrn_order, single_
 @cli.command()
 @click.argument('morph1')
 @click.argument('morph2')
+@click.option('--rtol', type=float, default=None, help='The relative tolerance. '
+              'See https://numpy.org/doc/stable/reference/generated/numpy.allclose.html')
+@click.option('--atol', type=float, default=None, help='The absolute tolerance. '
+              'See https://numpy.org/doc/stable/reference/generated/numpy.allclose.html')
 @click.option('--quiet/--no-quiet', default=False)
-def diff(morph1, morph2, quiet):
+def diff(morph1, morph2, rtol, atol, quiet):
     '''
     Compare two morphology files.
 
@@ -135,7 +139,12 @@ def diff(morph1, morph2, quiet):
     if quiet:
         L.setLevel(logging.WARNING)
 
-    result = morph_tool.diff(morph1, morph2)
+    kwargs = {}
+    if atol is not None:
+        kwargs['atol'] = atol
+    if rtol is not None:
+        kwargs['rtol'] = rtol
+    result = morph_tool.diff(morph1, morph2, **kwargs)
     if result:
         L.info("Morphologies not identical")
         L.info(result.info)

--- a/morph_tool/morphio_diff.py
+++ b/morph_tool/morphio_diff.py
@@ -75,7 +75,7 @@ def diff(morph1, morph2, rtol=1.e-5, atol=1.e-8):
                                   'Attributes Section.{} of:\n'
                                   '{}\n{}\nhave different shapes: {} vs {}'.format(
                                       attrib, section1, section2, val1.shape, val2.shape))
-            is_close = isclose(val1, val2, rtol=rtol, atol=atol)
+            is_close = np.isclose(val1, val2, rtol=rtol, atol=atol)
             if not is_close.all():
                 first_diff_index = np.where(~is_close)[0][0]
 

--- a/morph_tool/morphio_diff.py
+++ b/morph_tool/morphio_diff.py
@@ -75,9 +75,9 @@ def diff(morph1, morph2, rtol=1.e-5, atol=1.e-8):
                                   'Attributes Section.{} of:\n'
                                   '{}\n{}\nhave different shapes: {} vs {}'.format(
                                       attrib, section1, section2, val1.shape, val2.shape))
-            _isclose = isclose(val1, val2, rtol=rtol, atol=atol)
-            if not _isclose.all():
-                first_diff_index = np.where(~_isclose)[0][0]
+            is_close = isclose(val1, val2, rtol=rtol, atol=atol)
+            if not is_close.all():
+                first_diff_index = np.where(~is_close)[0][0]
 
                 return DiffResult(True,
                                   f'Attributes Section.{attrib} of:\n'

--- a/morph_tool/morphio_diff.py
+++ b/morph_tool/morphio_diff.py
@@ -2,8 +2,9 @@
 to see if two morphologies are the same or not'''
 import logging
 
-from numpy import allclose
+import numpy as np
 from morphio import Morphology
+from numpy import isclose
 
 logger = logging.getLogger('morph_tool')
 
@@ -53,8 +54,8 @@ def diff(morph1, morph2, rtol=1.e-5, atol=1.e-8):
     Args:
         morph1 (str|morphio.Morphology|morphio.mut.Morphology): a morphology
         morph2 (str|morphio.Morphology|morphio.mut.Morphology): a morphology
-        rtol (float): the relative tolerance used for comparing points (see numpy.allclose help)
-        atol (float): the absolute tolerance used for comparing points (see numpy.allclose help)
+        rtol (float): the relative tolerance used for comparing points (see numpy.isclose help)
+        atol (float): the absolute tolerance used for comparing points (see numpy.isclose help)
     '''
 
     if not isinstance(morph1, Morphology):
@@ -74,11 +75,16 @@ def diff(morph1, morph2, rtol=1.e-5, atol=1.e-8):
                                   'Attributes Section.{} of:\n'
                                   '{}\n{}\nhave different shapes: {} vs {}'.format(
                                       attrib, section1, section2, val1.shape, val2.shape))
-            if not allclose(val1, val2, rtol=rtol, atol=atol):
+            _isclose = isclose(val1, val2, rtol=rtol, atol=atol)
+            if not _isclose.all():
+                first_diff_index = np.where(~_isclose)[0][0]
+
                 return DiffResult(True,
-                                  'Attributes Section.{} of:\n'
-                                  '{}\n{}\nhave the same shape but different values'.format(
-                                      attrib, section1, section2))
+                                  f'Attributes Section.{attrib} of:\n'
+                                  f'{section1}\n{section2}\nhave the same shape '
+                                  'but different values\n'
+                                  f'Vector {attrib} differs at index {first_diff_index}: '
+                                  f'{val1[first_diff_index]} != {val2[first_diff_index]}')
         if section1.type != section2.type:
             return DiffResult(True, '{} and {} have different section types'.format(
                 section1, section2))

--- a/morph_tool/morphio_diff.py
+++ b/morph_tool/morphio_diff.py
@@ -4,7 +4,6 @@ import logging
 
 import numpy as np
 from morphio import Morphology
-from numpy import isclose
 
 logger = logging.getLogger('morph_tool')
 

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -1,9 +1,11 @@
-from os.path import dirname, join as joinp
-from nose.tools import assert_equal, ok_
+from os.path import dirname
+from os.path import join as joinp
+
 from click.testing import CliRunner
 from morph_tool import diff
-from morphio import PointLevel, SectionType, set_ignored_warning, Warning
+from morphio import PointLevel, SectionType, Warning, set_ignored_warning
 from morphio.mut import Morphology
+from nose.tools import assert_equal, ok_
 
 DATA = joinp(dirname(__file__), 'data')
 
@@ -34,7 +36,8 @@ def test_equality():
                  '\n'.join(['Attributes Section.points of:',
                             'Section(id=1, points=[(0 5 0),..., (-6 5 0)])',
                             'Section(id=1, points=[(0 0 0),..., (0 0 1)])',
-                            'have the same shape but different values']))
+                            'have the same shape but different values',
+                            'Vector points differs at index 0: [0. 5. 0.] != [0. 0. 0.]']))
 
     a = Morphology(joinp(DATA, 'simple2.asc'))
     mundane_section(a).diameters = [0,0,0]
@@ -44,7 +47,8 @@ def test_equality():
                  '\n'.join(['Attributes Section.diameters of:',
                             'Section(id=1, points=[(0 5 0),..., (-6 5 0)])',
                             'Section(id=1, points=[(0 5 0),..., (-6 5 0)])',
-                            'have the same shape but different values']))
+                            'have the same shape but different values',
+                            'Vector diameters differs at index 0: 2.0 != 0.0']))
 
     a = Morphology(joinp(DATA, 'simple2.asc'))
     for section in a.iter():


### PR DESCRIPTION
## --rtol and --atol can now be passed to the CLI

to change the tolerances.
See https://numpy.org/doc/stable/reference/generated/numpy.allclose.html

## better logging

When two morphologies differ, it will report which index of the vector differs
and the values that differ.

### Example
```
$ morph-tool diff actual.h5 expected.h5 --rtol 0.1

INFO:morph_tool:Morphologies not identical
INFO:morph_tool:Attributes Section.diameters of:
Section(id=0, points=[(-5.006 -1.56494 -1.50834),..., (-17.1488 -8.69046 -6.10697)])
Section(id=0, points=[(-5.006 -1.56494 -1.50834),..., (-17.1488 -8.69046 -6.10697)])
have the same shape but different values
Vector diameters differs at index 1: 0.8771874904632568 != 0.48936277627944946
```