### PR TITLE
Make MorphDB.df hashable

### DIFF
--- a/morph_tool/morphdb.py
+++ b/morph_tool/morphdb.py
@@ -218,9 +218,9 @@ class MorphDB:
 
     @classmethod
     def from_neurondb(cls,
-                      neurondb: Path,
+                      neurondb: Union[Path, str],
                       label: str = 'default',
-                      morphology_folder: Optional[Path] = None):
+                      morphology_folder: Optional[Union[Path, str]] = None):
         '''Builds a MorphologyDB from a neurondb.(xml|dat) file
         Args:
             neurondb: path to a neurondb.(xml|dat) file
@@ -233,7 +233,7 @@ class MorphDB:
 
         ..note:: missing keys are filled with `True` values
         '''
-        morphology_folder = morphology_folder or neurondb.parent.resolve()
+        morphology_folder = Path(morphology_folder) or Path(neurondb).parent.resolve()
 
         morph_paths = {path.stem: path for path in iter_morphology_files(morphology_folder)}
 
@@ -244,7 +244,7 @@ class MorphDB:
 
     @classmethod
     def from_folder(cls,
-                    morphology_folder: Path,
+                    morphology_folder: Union[Path, str],
                     mtypes: Iterable[Tuple[str, str]],
                     label: str = 'default',
                     extension: Optional[str] = None):
@@ -259,7 +259,7 @@ class MorphDB:
         Raises: ValueError if the folder contains multiple files with the same name but
         different extensions and the extension argument has not been provided
         '''
-        files = list(iter_morphology_files(morphology_folder,
+        files = list(iter_morphology_files(Path(morphology_folder),
                                            extensions={extension} if extension else None))
         if not extension:
             duplicates = [item for item, count in

--- a/morph_tool/morphdb.py
+++ b/morph_tool/morphdb.py
@@ -233,7 +233,10 @@ class MorphDB:
 
         ..note:: missing keys are filled with `True` values
         '''
-        morphology_folder = Path(morphology_folder) or Path(neurondb).parent.resolve()
+        if morphology_folder:
+            morphology_folder = Path(morphology_folder)
+        else:
+            morphology_folder = Path(neurondb).parent.resolve()
 
         morph_paths = {path.stem: path for path in iter_morphology_files(morphology_folder)}
 

--- a/morph_tool/morphdb.py
+++ b/morph_tool/morphdb.py
@@ -162,7 +162,7 @@ class MorphDB:
         """
         self.df = pd.DataFrame([morph_info.row for morph_info in (morph_info_seq or ())],
                                columns=COLUMNS)
-        self._sanitize_df_types()
+        MorphDB._sanitize_df_types(self.df)
 
     @classmethod
     def _from_neurondb_dat(cls, neurondb, morph_paths, label):

--- a/tests/test_morphdb.py
+++ b/tests/test_morphdb.py
@@ -4,7 +4,7 @@ from tempfile import TemporaryDirectory
 
 import morph_tool.morphdb as tested
 import pandas as pd
-from nose.tools import assert_raises
+from nose.tools import assert_raises, assert_true
 from numpy.testing import assert_array_equal, assert_equal
 from pandas.testing import assert_frame_equal
 
@@ -179,4 +179,4 @@ def test_check_file_exists():
 def test_hashable():
     morphology_folder = DATA_DIR / 'morphdb/from_neurondb/'
     db = tested.MorphDB.from_neurondb(morphology_folder / 'neurondb-msubtype.xml')
-    assert_equal(hash(db), 8764646863631)
+    assert_true(hash(db) != 0)

--- a/tests/test_morphdb.py
+++ b/tests/test_morphdb.py
@@ -178,5 +178,5 @@ def test_check_file_exists():
 
 def test_hashable():
     morphology_folder = DATA_DIR / 'morphdb/from_neurondb/'
-    df = tested.MorphDB.from_neurondb(morphology_folder / 'neurondb-msubtype.xml').df
-    assert_equal(hash(df), None)
+    db = tested.MorphDB.from_neurondb(morphology_folder / 'neurondb-msubtype.xml')
+    assert_equal(db, None)

--- a/tests/test_morphdb.py
+++ b/tests/test_morphdb.py
@@ -179,4 +179,4 @@ def test_check_file_exists():
 def test_hashable():
     morphology_folder = DATA_DIR / 'morphdb/from_neurondb/'
     db = tested.MorphDB.from_neurondb(morphology_folder / 'neurondb-msubtype.xml')
-    assert_equal(db, None)
+    assert_equal(hash(db), None)

--- a/tests/test_morphdb.py
+++ b/tests/test_morphdb.py
@@ -179,4 +179,4 @@ def test_check_file_exists():
 def test_hashable():
     morphology_folder = DATA_DIR / 'morphdb/from_neurondb/'
     db = tested.MorphDB.from_neurondb(morphology_folder / 'neurondb-msubtype.xml')
-    assert_equal(hash(db), None)
+    assert_equal(hash(db), 8764646863631)

--- a/tests/test_morphdb.py
+++ b/tests/test_morphdb.py
@@ -174,3 +174,9 @@ def test_check_file_exists():
         DATA_DIR / 'morphdb/from_neurondb/neurondb-only-dat-info.xml')
     original.df.loc[1, 'path'] = Path('/non/existing/path')
     assert_raises(ValueError, original.check_files_exist)
+
+
+def test_hashable():
+    morphology_folder = DATA_DIR / 'morphdb/from_neurondb/'
+    df = tested.MorphDB.from_neurondb(morphology_folder / 'neurondb-msubtype.xml').df
+    assert_equal(hash(df), None)


### PR DESCRIPTION
### Context

MorphDB.df is currently not hashable because of the column `axon_input` which is a list. And lists are not hashable.

### Resolution

Change `axon_input` column to a tuple to make the dataframe hashable

Fixes #52 


