### PR TITLE
Introduce axon point module

### DIFF
--- a/morph_tool/__init__.py
+++ b/morph_tool/__init__.py
@@ -2,6 +2,7 @@
 from morphio import LogLevel, Morphology
 
 from morph_tool.apical_point import apical_point_position, apical_point_section_segment
+from morph_tool.axon_point import axon_point_section
 from morph_tool.converter import convert
 from morph_tool.morphio_diff import diff
 from morph_tool.spatial import point_to_section_segment

--- a/morph_tool/axon_point.py
+++ b/morph_tool/axon_point.py
@@ -5,7 +5,7 @@ import numpy as np
 from neurom import COLS
 from morphio import SectionType, IterType
 
-logger = logging.getLogger("morph_tool")
+L = logging.getLogger(__name__)
 
 
 def axon_point_section(morph, direction=None, bbox=None):
@@ -24,16 +24,17 @@ def axon_point_section(morph, direction=None, bbox=None):
     Returns:
         MorphIO section ID for which the last point is the axon point
     """
-    if direction is None:
-        direction = [0.0, -1.0, 0.0]
-    else:
-        direction /= np.linalg.norm(direction)
 
     def _get_angle(section, direction):
         """Get angle between section endpoints and direction."""
         _diff = np.diff(section.points, axis=0)
         angles = np.arccos(np.dot(direction, _diff.T) / np.linalg.norm(_diff, axis=1))
         return list(angles[~np.isnan(angles)])  # in case we have duplicate points
+
+    if direction is None:
+        direction = [0.0, -1.0, 0.0]
+    else:
+        direction /= np.linalg.norm(direction)
 
     qualities = []
     ids = []
@@ -62,5 +63,5 @@ def axon_point_section(morph, direction=None, bbox=None):
     if len(qualities) > 0:
         return ids[np.argmin(qualities)]
     else:
-        logger.warning("Could not find axon point in bounding box %s, we return None", bbox)
+        L.warning("Could not find axon point in bounding box %s, we return None", bbox)
         return None

--- a/morph_tool/axon_point.py
+++ b/morph_tool/axon_point.py
@@ -2,6 +2,7 @@
 import logging
 import numpy as np
 
+from neurom import COLS
 from morphio import SectionType, IterType
 
 logger = logging.getLogger("morph_tool")
@@ -45,8 +46,10 @@ def axon_point_section(morph, direction=None, bbox=None):
             positions.append(section.points[-1])
 
     if bbox is not None:
-        qualities, positions, ids = np.array(qualities), np.array(positions), np.array(ids)
-        _convert = {"x": 0, "y": 1, "z": 2}
+        qualities = np.array(qualities)
+        positions = np.array(positions)
+        ids = np.array(ids)
+        _convert = {"x": COLS.X, "y": COLS.Y, "z": COLS.Z}
         for axis, bounds in bbox.items():
             bbox_filter = np.where(
                 (positions[:, _convert[axis]] > bounds[0])

--- a/morph_tool/axon_point.py
+++ b/morph_tool/axon_point.py
@@ -32,15 +32,17 @@ def axon_point_section(morph, direction=None, bbox=None):
     def _get_angle(section, direction):
         """Get angle between section endpoints and direction."""
         return np.arccos(
-            np.dot(direction, section.points[-1] - section.points[0])
-            / (np.linalg.norm(section.points[-1] - section.points[0]))
-        )
+            np.dot(direction, np.diff(section.points, axis=0).T)
+            / np.linalg.norm(np.diff(section.points, axis=0), axis=1)
+        ).mean()
 
     qualities, ids, positions = [], [], []
     for section in morph.iter():
         if section.type == SectionType.axon and not section.children:
             qualities.append(
-                sum(_get_angle(section, direction) for section in section.iter(IterType.upstream))
+                np.mean(
+                    [_get_angle(section, direction) for section in section.iter(IterType.upstream)]
+                )
             )
             ids.append(section.id)
             positions.append(section.points[-1])

--- a/morph_tool/axon_point.py
+++ b/morph_tool/axon_point.py
@@ -1,0 +1,63 @@
+"""Module to detect the terminal point of the main axon/"""
+import numpy as np
+
+from morphio import SectionType, IterType
+import logging
+
+logger = logging.getLogger("morph_tool")
+
+
+def get_axon_point(morph, direction=None, bbox=None):
+    """Estimate axon point as the terminal point of the main axon.
+
+    This point is defined as the point for which the sum of the angles with the direction vector
+    is minimal. This corresponds to a main axon being a branch that follows best a straight line
+    in the given direction. More constraints can be added with bbox argument, if incorect axon is
+    detected.
+
+    Args:
+        morph (morphio.Morphology): morphology
+        direction (ndarray): estimated direction of main axon, if None [0, -1, 0] is used
+        bbox (dict): bbox of the form {'x': [-100, 100], 'y': [-500, -400]}
+
+    Returns:
+        MorphIO section ID for which the last point is the axon point
+    """
+    if direction is None:
+        direction = [0.0, -1.0, 0.0]
+    else:
+        direction /= np.linalg.norm(direction)
+
+    def _get_angle(section, direction):
+        """Get angle between section endpoints and direction."""
+        return np.arccos(
+            np.dot(direction, section.points[-1] - section.points[0])
+            / (np.linalg.norm(section.points[-1] - section.points[0]))
+        )
+
+    qualities, ids, positions = [], [], []
+    for section in morph.iter():
+        if section.type == SectionType.axon and not section.children:
+            qualities.append(
+                sum(_get_angle(section, direction) for section in section.iter(IterType.upstream))
+            )
+            ids.append(section.id)
+            positions.append(section.points[-1])
+
+    if bbox is not None:
+        qualities, positions, ids = np.array(qualities), np.array(positions), np.array(ids)
+        _convert = {"x": 0, "y": 1, "z": 2}
+        for axis, bounds in bbox.items():
+            bbox_filter = np.where(
+                (positions[:, _convert[axis]] > bounds[0])
+                & (positions[:, _convert[axis]] < bounds[1])
+            )
+            qualities = qualities[bbox_filter]
+            positions = positions[bbox_filter]
+            ids = ids[bbox_filter]
+
+    if len(qualities) > 0:
+        return ids[np.argmin(qualities)]
+    else:
+        logger.warning("Could not find axon point in bounding box %s, we return None", bbox)
+        return None

--- a/morph_tool/axon_point.py
+++ b/morph_tool/axon_point.py
@@ -1,13 +1,13 @@
 """Module to detect the terminal point of the main axon/"""
+import logging
 import numpy as np
 
 from morphio import SectionType, IterType
-import logging
 
 logger = logging.getLogger("morph_tool")
 
 
-def get_axon_point(morph, direction=None, bbox=None):
+def axon_point_section(morph, direction=None, bbox=None):
     """Estimate axon point as the terminal point of the main axon.
 
     This point is defined as the point for which the sum of the angles with the direction vector

--- a/morph_tool/axon_point.py
+++ b/morph_tool/axon_point.py
@@ -60,7 +60,6 @@ def axon_point_section(morph, direction=None, bbox=None):
             ids = ids[bbox_filter]
 
     if len(qualities) > 0:
-        print(sorted(qualities))
         return ids[np.argmin(qualities)]
     else:
         logger.warning("Could not find axon point in bounding box %s, we return None", bbox)

--- a/morph_tool/morphdb.py
+++ b/morph_tool/morphdb.py
@@ -331,7 +331,7 @@ class MorphDB:
         Raises:
             ValueError: if `self.df` has undefined (ie. None) paths
         '''
-        missing_morphs = self.df[self.df.path.isnull()].name.values
+        missing_morphs = self.df[self.df.path.isnull()].name.to_list()
         if missing_morphs:
             raise ValueError(
                 f'DataFrame has morphologies with undefined filepaths: {missing_morphs}')

--- a/morph_tool/morphdb.py
+++ b/morph_tool/morphdb.py
@@ -233,17 +233,18 @@ class MorphDB:
 
         ..note:: missing keys are filled with `True` values
         '''
+        neurondb = Path(neurondb)
         if morphology_folder:
             morphology_folder = Path(morphology_folder)
         else:
-            morphology_folder = Path(neurondb).parent.resolve()
+            morphology_folder = neurondb.parent.resolve()
 
         morph_paths = {path.stem: path for path in iter_morphology_files(morphology_folder)}
 
         if neurondb.suffix.lower() == '.dat':
-            return cls._from_neurondb_dat(Path(neurondb), morph_paths, label)
+            return cls._from_neurondb_dat(neurondb, morph_paths, label)
         else:
-            return cls._from_neurondb_xml(Path(neurondb), morph_paths, label)
+            return cls._from_neurondb_xml(neurondb, morph_paths, label)
 
     @classmethod
     def from_folder(cls,

--- a/morph_tool/resampling.py
+++ b/morph_tool/resampling.py
@@ -131,10 +131,6 @@ def _parametric_values(values, ids, fractions):
     new_values[-1] = values[-1]
     new_values[1:-1] = values[ids] + fractions * (values[ids + 1] - values[ids])
 
-    if len(fractions) > 0 and fractions[-1] > 1 - 1e-5:
-        new_values[-2] = new_values[-1]
-        new_values = new_values[:-1]
-
     return new_values
 
 

--- a/morph_tool/resampling.py
+++ b/morph_tool/resampling.py
@@ -131,6 +131,10 @@ def _parametric_values(values, ids, fractions):
     new_values[-1] = values[-1]
     new_values[1:-1] = values[ids] + fractions * (values[ids + 1] - values[ids])
 
+    if len(fractions) > 0 and fractions[-1] > 1 - 1e-5:
+        new_values[-2] = new_values[-1]
+        new_values = new_values[:-1]
+
     return new_values
 
 

--- a/tests/test_axon_point.py
+++ b/tests/test_axon_point.py
@@ -4,7 +4,7 @@ from nose.tools import eq_
 from morph_tool import axon_point_section
 
 
-DATA = Path(__file__).absolute().parents[0] / "data"
+DATA = Path(__file__).absolute().parent / "data"
 
 
 def test_axon_point_section():

--- a/tests/test_axon_point.py
+++ b/tests/test_axon_point.py
@@ -11,7 +11,7 @@ DATA = os.path.join(os.path.abspath(os.path.dirname(__file__)), "data")
 def test_get_apical_point():
     morph = Morphology(os.path.join(DATA, "neuron.asc"))
 
-    eq_(axon_point_section(morph), 100)
-    eq_(axon_point_section(morph, direction=[1.0, 0, 0]), 142)
+    eq_(axon_point_section(morph), 98)
+    eq_(axon_point_section(morph, direction=[1.0, 0, 0]), 140)
     eq_(axon_point_section(morph, bbox={"x": [-10, 10]}), 136)
-    eq_(axon_point_section(morph, bbox={"x": [-100, 100], "y": [-100, 100]}), 100)
+    eq_(axon_point_section(morph, bbox={"x": [-100, 100], "y": [-100, 100]}), 142)

--- a/tests/test_axon_point.py
+++ b/tests/test_axon_point.py
@@ -1,15 +1,14 @@
-import os
-
+from pathlib import Path
 from morphio import Morphology
 from nose.tools import eq_
 from morph_tool import axon_point_section
 
 
-DATA = os.path.join(os.path.abspath(os.path.dirname(__file__)), "data")
+DATA = Path(__file__).absolute().parents[0] / "data"
 
 
-def test_get_apical_point():
-    morph = Morphology(os.path.join(DATA, "neuron.asc"))
+def test_axon_point_section():
+    morph = Morphology(DATA / "neuron.asc")
 
     eq_(axon_point_section(morph), 98)
     eq_(axon_point_section(morph, direction=[1.0, 0, 0]), 140)

--- a/tests/test_axon_point.py
+++ b/tests/test_axon_point.py
@@ -1,0 +1,17 @@
+import os
+
+from morphio import Morphology
+from nose.tools import eq_
+from morph_tool import axon_point_section
+
+
+DATA = os.path.join(os.path.abspath(os.path.dirname(__file__)), "data")
+
+
+def test_get_apical_point():
+    morph = Morphology(os.path.join(DATA, "neuron.asc"))
+
+    eq_(axon_point_section(morph), 100)
+    eq_(axon_point_section(morph, direction=[1.0, 0, 0]), 142)
+    eq_(axon_point_section(morph, bbox={"x": [-10, 10]}), 136)
+    eq_(axon_point_section(morph, bbox={"x": [-100, 100], "y": [-100, 100]}), 100)


### PR DESCRIPTION
### Context

Similar to apical point detection, having an axon point detection is useful. The axon point is defined as the terminal of the main axon, only for PC axons. A PC axon has a main thick branch from the soma going donwards, from which smaller branches emerge. For electrical models and correct axon diametrizations, detecting which branch is the main axon is crucial.

### Resolution

We propose an algorithm with @mzbili in this PR.
