### PR TITLE
fix duplicate point

### DIFF
--- a/morph_tool/resampling.py
+++ b/morph_tool/resampling.py
@@ -133,6 +133,10 @@ def _parametric_values(values, ids, fractions):
     new_values[-1] = values[-1]
     new_values[1:-1] = values[ids] + fractions * (values[ids + 1] - values[ids])
 
+    # in case the last fraction is close to one, we don't save the last interpolated point
+    if fractions[-1] > 1 - 1e-5:
+        new_values[-2] = new_values[-1]
+        new_values = new_values[:-1]
     return new_values
 
 

--- a/morph_tool/resampling.py
+++ b/morph_tool/resampling.py
@@ -134,7 +134,7 @@ def _parametric_values(values, ids, fractions):
     new_values[1:-1] = values[ids] + fractions * (values[ids + 1] - values[ids])
 
     # in case the last fraction is close to one, we don't save the last interpolated point
-    if fractions[-1] > 1 - 1e-5:
+    if len(fractions) > 0 and fractions[-1] > 1 - 1e-5:
         new_values[-2] = new_values[-1]
         new_values = new_values[:-1]
     return new_values


### PR DESCRIPTION
### Context

In rare cases, the last fraction is close to 1, resulting in a duplicated point (breaking for example repair of neuror)

### Resolution

Sort of hacky solution, not sure how to best do it.

Here is a dendrite which creates this issue with linear_density=1.0:
```
( (Color Red)
  (Dendrite)
  (-1.474797606 -12.873973846 1.465831757 1.179999948)
  (-1.268972993 -13.383681297 1.386174798 1.179999948)
  (-1.207281470 -13.681849480 1.339448690 1.179999948)
  (-0.772920549 -14.285424232 1.751677036 1.179999948)
  (-0.640972078 -14.575642586 1.706354022 1.179999948)
  (-0.157932609 -15.903386116 1.498738170 1.179999948)
  (0.108525813 -16.787338257 1.856412053 1.179999948)
  (0.603999615 -17.670700073 1.718663454 1.179999948)
  (1.443708062 -19.519208908 1.925997615 1.179999948)
  (1.577559590 -19.740325928 1.891538978 1.179999948)
  (2.688630342 -22.260030746 2.004102230 1.179999948)
  (3.322759628 -23.588979721 2.292642832 1.179999948)
  (4.462557793 -25.080135345 2.556796074 1.179999948)
  (4.665114880 -25.744903564 2.948777676 1.179999948)
)
```


