### PR TITLE
Fix resampling duplicate point because of numerical imprecision

### DIFF
--- a/morph_tool/resampling.py
+++ b/morph_tool/resampling.py
@@ -81,10 +81,8 @@ def _resample_from_linear_density(points, linear_density):
     n_segments = max(1, int(total_length * linear_density))
 
     # split total length in n_segments of equal length dl
-    dl = total_length / n_segments
-
     # vertex path lengths without including first and last (K-2)
-    new_path_lengths = np.arange(dl, total_length, dl)
+    new_path_lengths = np.arange(1, n_segments) * total_length / n_segments
 
     # ids of the starting points for the parametric equation
     ids = np.searchsorted(path_lengths, new_path_lengths) - 1


### PR DESCRIPTION
@arnaudon encountered an issue when resampling neuronal morphologies where the two last resampled points were identical.

This was due to the numerical imprecision of the cumulative values in `np.arange(dl, total_length, dl)`. In some cases, due to the numerical error of the summation, the value `total_length` was returned at the end of the array.

To fix this the arrange is converted to `np.arange(1, n_segments) * dl` to avoid such errors and ensure that the correct size is always created.