### PR TITLE
Fix NestedPool for py38

### DIFF
--- a/morph_tool/morphio_diff.py
+++ b/morph_tool/morphio_diff.py
@@ -60,7 +60,7 @@ def diff(morph1, morph2, rtol=1.e-5, atol=1.e-8):
 
     if len(morph1.root_sections) != len(morph2.root_sections):
         return DiffResult(True,
-                          'Both morphologies have different a different number of root sections')
+                          'Both morphologies have a different number of root sections')
 
     for section1, section2 in zip(morph1.iter(), morph2.iter()):
         for attrib in ['points', 'diameters', 'perimeters']:
@@ -85,7 +85,7 @@ def diff(morph1, morph2, rtol=1.e-5, atol=1.e-8):
                 section1, section2))
         if len(section1.children) != len(section2.children):
             return DiffResult(True,
-                              '{} and {} have different a different number of children'.format(
+                              '{} and {} have a different number of children'.format(
                                   section1, section2))
 
     return DiffResult(False)

--- a/morph_tool/nrnhines.py
+++ b/morph_tool/nrnhines.py
@@ -278,7 +278,24 @@ class NestedPool(multiprocessing.pool.Pool):  # pylint: disable=abstract-method
 
     class Process(multiprocessing.Process):
         """Class that represents a non-daemon process"""
-        daemon = False
+
+        def __init__(self, *args, **kwargs):
+            """Ensures group=None to avoid exception from multiprocessing.
+
+            Note:
+                The exception raised by multiprocessing is:
+                AssertionError: group argument must be None for now
+            """
+            kwargs.pop("group", None)
+            super().__init__(None, *args[1:], **kwargs)
+
+        @property
+        def daemon(self):
+            return False
+
+        @daemon.setter
+        def daemon(self, value):
+            pass
 
 
 def isolate(func):

--- a/tests/data/morphdb/from_neurondb/features.csv
+++ b/tests/data/morphdb/from_neurondb/features.csv
@@ -1,4 +1,4 @@
 properties,properties,properties,properties,properties,properties,properties,properties,properties,properties,properties,properties,properties,properties,properties,properties,properties,axon,basal_dendrite,apical_dendrite,all
 name,mtype,msubtype,mtype_no_subtype,layer,label,path,use_axon,use_dendrites,axon_repair,dendrite_repair,basal_dendrite_repair,tuft_dendrite_repair,oblique_dendrite_repair,unravel,use_for_stats,axon_inputs,max_section_length,max_section_length,max_section_length,max_section_length
-tkb061126a4_ch0_cc2_h_zk_60x_1,L1_DAC,,L1_DAC,1,default,/home/runner/work/morph-tool/morph-tool/tests/data/morphdb/from_neurondb/tkb061126a4_ch0_cc2_h_zk_60x_1.h5,True,True,True,True,True,True,True,True,True,(),464.12187202802545,162.41220764649324,536.7585059841872,536.7585059841872
-simple3,L1_DAC,,L1_DAC,1,default,/home/runner/work/morph-tool/morph-tool/tests/data/morphdb/from_neurondb/simple3.asc,True,True,True,True,True,True,True,True,True,(),6.0,7.896464810537854,,7.896464810537854
+tkb061126a4_ch0_cc2_h_zk_60x_1,L1_DAC,,L1_DAC,1,default,tkb061126a4_ch0_cc2_h_zk_60x_1.h5,True,True,True,True,True,True,True,True,True,(),464.12187202802545,162.41220764649324,536.7585059841872,536.7585059841872
+simple3,L1_DAC,,L1_DAC,1,default,simple3.asc,True,True,True,True,True,True,True,True,True,(),6.0,7.896464810537854,,7.896464810537854

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -1,3 +1,4 @@
+from pkg_resources import get_distribution, parse_version
 from os.path import dirname
 from os.path import join as joinp
 
@@ -66,14 +67,17 @@ def test_equality():
     mundane_section(a).append_section(PointLevel([[-6, 5, 0], [4, 5, 6]], [2, 3]))
     result = diff(neuron_ref, a)
     ok_(result)
-    assert_equal(result.info, 'Section(id=1, points=[(0 5 0),..., (-6 5 0)]) and Section(id=1, points=[(0 5 0),..., (-6 5 0)]) have different a different number of children')
+    assert_equal(result.info, 'Section(id=1, points=[(0 5 0),..., (-6 5 0)]) and Section(id=1, points=[(0 5 0),..., (-6 5 0)]) have a different number of children')
 
     a = Morphology(joinp(DATA, 'simple2.asc'))
     a.delete_section(a.root_sections[0])
     result = diff(neuron_ref, a)
     ok_(result)
-    assert_equal(result.info, 'Both morphologies have different a different number of root sections')
+    assert_equal(result.info, 'Both morphologies have a different number of root sections')
 
     result = diff(joinp(DATA, 'single_child.asc'), joinp(DATA, 'not_single_child.asc'))
-    ok_(not result)
+    if parse_version(get_distribution("morphio").version) < parse_version("3"):
+        ok_(not result)
+    else:
+        ok_(result)
     set_ignored_warning([Warning.wrong_duplicate, Warning.only_child], False)

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ testdeps =
 
 [tox]
 envlist =
-    {py36, py37}
+    {py36, py37, py38}
     check-dist
     lint
     docs
@@ -16,7 +16,7 @@ envlist =
 [testenv]
 extras = all
 deps = {[base]testdeps}
-commands = nosetests -sv tests
+commands = nosetests -sv tests {posargs}
 
 [testenv:check-dist]
 deps = twine
@@ -41,7 +41,7 @@ deps =
     coverage
     nose
 commands =
-    coverage run --source {[base]name} {envbindir}/nosetests tests
+    coverage run --source {[base]name} {envbindir}/nosetests tests {posargs}
     coverage report --show-missing
     coverage xml
 
@@ -49,7 +49,7 @@ commands =
 deps = {[base]testdeps}
        gitpython
        tqdm
-commands = nosetests functional_tests
+commands = nosetests functional_tests {posargs}
 
 [testenv:docs]
 changedir = doc


### PR DESCRIPTION
### Context

NestedPool fails for Py38

### Resolution

Force the ``group`` argument to None in the constructor of ``NestedPool.Process``.