### PR TITLE
MorphLoader can now return mutable Morphology objects

### DIFF
--- a/morph_tool/loader.py
+++ b/morph_tool/loader.py
@@ -29,17 +29,21 @@ class MorphLoader(object):
         cache_size: size of LRU cache (if `None`, the cache can grow without bound,
             if 0, no lru_cache is used)
     """
-    def __init__(self, base_dir, file_ext, cache_size=None):
+    def __init__(self, base_dir, file_ext, cache_size=None, mut_morphologies=False):
         self.base_dir = base_dir
         self.file_ext = _ensure_startswith_point(file_ext)
         if cache_size == 0:
             self.get = self._get
         else:
             self.get = lru_cache(maxsize=cache_size)(self._get)
+        if mut_morphologies:
+            self._morph_loader = morphio.mut.Morphology
+        else:
+            self._morph_loader = morphio.Morphology
 
     def _get(self, name, options=None):
         filepath = os.path.join(self.base_dir, name + self.file_ext)
         if options is None:
-            return morphio.Morphology(filepath)
+            return self._morph_loader(filepath)
         else:
-            return morphio.Morphology(filepath, options)
+            return self._morph_loader(filepath, options)

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -43,10 +43,19 @@ def test_loader(f_mock):
         mock.call('/dir/test.abc'),
     ])
 
+
 @patch('morphio.Morphology')
 def test_loader_no_cache(f_mock):
     f_mock.configure_mock(side_effect=lambda *args: object())
     loader = tested.MorphLoader('/dir', file_ext='abc', cache_size=0)
+    loader.get('test')
+    loader.get('test')
+    nt.assert_equal(f_mock.call_count, 2)
+
+
+@patch('morphio.mut.Morphology')
+def test_loader_mutable(f_mock):
+    loader = tested.MorphLoader('/dir', file_ext='abc', cache_size=0, mut_morphologies=True)
     loader.get('test')
     loader.get('test')
     nt.assert_equal(f_mock.call_count, 2)


### PR DESCRIPTION
### Context

The morphologies returned by `MorphLoader` are not mutable, so we have to call `morph.as_mutable()` to make it mutable before updating it. This PR allows to get mutable morphologies from MorphLoader.

### Resolution

The `MorphLoader` constructor has a new parameter to choose whether the returned morphologies should be mutable or not.