### PR TITLE
use isclose in spatial

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,7 +3,7 @@ Changelog
 
 Version 2.8.0
 -------------
-- Use numpy.isclose in spatial point_to_section_segment (#84)
+- Use numpy.isclose in spatial ``point_to_section_segment``. Add new keyword arguments ``rtol``,``atol`` to ``point_to_section_segment``.  (#84)
 - Add functionality to plot morphologies with synapses. Move all plot functionality under
   ``plot`` package. (#82)
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,7 +3,7 @@ Changelog
 
 Version 2.8.0
 -------------
-- use isclose in spatial point_to_section_segment (#84)
+- Use numpy.isclose in spatial point_to_section_segment (#84)
 - Add functionality to plot morphologies with synapses. Move all plot functionality under
   ``plot`` package. (#82)
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,7 @@ Changelog
 
 Version 2.8.0
 -------------
+- use isclose in spatial point_to_section_segment (#84)
 - Add functionality to plot morphologies with synapses. Move all plot functionality under
   ``plot`` package. (#82)
 

--- a/morph_tool/spatial.py
+++ b/morph_tool/spatial.py
@@ -1,11 +1,11 @@
-"""Module for spatial related functions"""
+'''Module for spatial related functions'''
 import numpy as np
 
 from neurom import COLS
 
 
 def point_to_section_segment(neuron, point, rtol=1e-05, atol=1e-08):
-    """Find section and segment that matches the point.
+    '''Find section and segment that matches the point.
 
     Only the first point found with the *exact* same coordinates as the point argument is considered
 
@@ -17,7 +17,7 @@ def point_to_section_segment(neuron, point, rtol=1e-05, atol=1e-08):
     Returns:
         Tuple: (NeuroM/MorphIO section ID, point ID) of the point the matches the input coordinates.
         Since NeuroM v2, section ids of NeuroM and MorphIO are the same excluding soma.
-    """
+    '''
 
     for section in neuron.iter():
         points = section.points
@@ -27,4 +27,4 @@ def point_to_section_segment(neuron, point, rtol=1e-05, atol=1e-08):
         if offset[0].size:
             return section.id, offset[0][0]
 
-    raise ValueError("Cannot find point in morphology that matches: {}".format(point))
+    raise ValueError('Cannot find point in morphology that matches: {}'.format(point))

--- a/morph_tool/spatial.py
+++ b/morph_tool/spatial.py
@@ -22,9 +22,9 @@ def point_to_section_segment(neuron, point):
 
     for section in neuron.iter():
         points = section.points
-        offset = np.where((points[:, X] == point[COLS.X]) &
-                          (points[:, Y] == point[COLS.Y]) &
-                          (points[:, Z] == point[COLS.Z]))
+        offset = np.where(np.allclose(points[:, X], point[COLS.X]) &
+                          np.allclose(points[:, Y], point[COLS.Y]) &
+                          np.allclose(points[:, Z], point[COLS.Z]))
         if offset[0].size:
             return section.id, offset[0][0]
 

--- a/morph_tool/spatial.py
+++ b/morph_tool/spatial.py
@@ -1,31 +1,30 @@
-'''Module for spatial related functions'''
+"""Module for spatial related functions"""
 import numpy as np
 
 from neurom import COLS
 
-X, Y, Z = 0, 1, 2
 
-
-def point_to_section_segment(neuron, point):
-    '''Find section and segment that matches the point.
+def point_to_section_segment(neuron, point, rtol=1e-05, atol=1e-08):
+    """Find section and segment that matches the point.
 
     Only the first point found with the *exact* same coordinates as the point argument is considered
 
     Args:
         neuron (morphio.Morphology): neuron object
         point (point): value of the point to find in the h5 file
+        rtol, atol (floats): precission of np.isclose
 
     Returns:
         Tuple: (NeuroM/MorphIO section ID, point ID) of the point the matches the input coordinates.
         Since NeuroM v2, section ids of NeuroM and MorphIO are the same excluding soma.
-    '''
+    """
 
     for section in neuron.iter():
         points = section.points
-        offset = np.where(np.allclose(points[:, X], point[COLS.X]) &
-                          np.allclose(points[:, Y], point[COLS.Y]) &
-                          np.allclose(points[:, Z], point[COLS.Z]))
+        offset = np.where(
+            np.isclose(points[:, COLS.XYZ], point[COLS.XYZ], rtol=rtol, atol=atol).all(axis=1)
+        )
         if offset[0].size:
             return section.id, offset[0][0]
 
-    raise ValueError('Cannot find point in morphology that matches: {}'.format(point))
+    raise ValueError("Cannot find point in morphology that matches: {}".format(point))

--- a/tests/test_spatial.py
+++ b/tests/test_spatial.py
@@ -1,11 +1,13 @@
 import os
 from nose.tools import eq_, assert_raises
+from pathlib import Path
 from morphio import Morphology
 
 from morph_tool import spatial
 
 
-DATA = os.path.join(os.path.abspath(os.path.dirname(__file__)), 'data')
+DATA = Path(__file__).absolute().parent / "data"
+
 
 def test_point_to_section_segment():
     neuron = Morphology(os.path.join(DATA, 'apical_test.h5'))
@@ -15,3 +17,13 @@ def test_point_to_section_segment():
     eq_(segment, 1)
 
     assert_raises(ValueError, spatial.point_to_section_segment, neuron, [24, 0, 0])
+
+    section, segment = spatial.point_to_section_segment(
+        neuron, [0., 25.1, 0.], rtol=1e-1, atol=1e-1
+    )
+    eq_(section, 1)
+    eq_(segment, 1)
+
+    section, segment = spatial.point_to_section_segment(neuron, [0., 25.0001, 0.])
+    eq_(section, 1)
+    eq_(segment, 1)


### PR DESCRIPTION
### Context

In one instance, this failed as strict equalities were not working with rounding errors.

### Resolution

np.isclose solves it
