### PR TITLE
Fix language detection

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.asc linguist-detectable=false


### PR DESCRIPTION
### Context

Github language detection reports that 92% of this repository is AGS script because of the `*.asc` files.

### Resolution

Ignore `*.asc` files in `.gitattributes` file.