### PR TITLE
Fix dendrogram jittered dataframe not include group index

### DIFF
--- a/morph_tool/converter.py
+++ b/morph_tool/converter.py
@@ -94,7 +94,7 @@ def contour2centroid(mean, points):
     # find the major axis of the ellipsoid that best fits the shape
     # assuming (falsely in general) that the center is the mean
 
-    points = (points - mean)
+    points = points - mean
     eigen_values, eigen_vectors = eig(np.dot(points.T, points))
 
     # To be consistent with NEURON eigen vector directions
@@ -210,7 +210,7 @@ def from_swc(neuron, output_ext):
         if output_ext == 'asc':
             single_point_sphere_to_circular_contour(neuron)
     else:
-        raise Exception(
+        raise MorphToolException(
             f'A SWC morphology is not supposed to have a soma of type: {neuron.soma_type}')
 
     return neuron
@@ -258,10 +258,10 @@ def convert(input_file,
     output_ext = Path(outputfile).suffix
 
     if single_point_soma and output_ext.lower() != '.swc':
-        raise Exception('Single point soma is only applicable for swc output')
+        raise MorphToolException('Single point soma is only applicable for swc output')
 
     if output_ext.lower() not in ('.swc', '.asc', '.h5', ):
-        raise Exception('Output file format should be one swc, asc or h5')
+        raise MorphToolException('Output file format should be one swc, asc or h5')
 
     output_ext = output_ext[1:]  # Remove the dot
 
@@ -271,7 +271,7 @@ def convert(input_file,
                      'h5': from_h5_or_asc,
                      }[neuron.version[0]]
     except KeyError as e:
-        raise Exception(
+        raise MorphToolException(
             f'No converter for morphology type: {neuron.version}') from e
 
     L.info('Original soma type: %s', neuron.soma_type)

--- a/morph_tool/nrnhines.py
+++ b/morph_tool/nrnhines.py
@@ -181,7 +181,7 @@ def _compartment_paths(points, n_compartments):
 
         # the boundary is somewhere in between point #segment_id and #segment_id+1
         # Here we compute its position in term of relative pathlength
-        segment_fraction = (remaining_pathlength / segment_lengths[segment_id])
+        segment_fraction = remaining_pathlength / segment_lengths[segment_id]
         position = points[segment_id] + segment_fraction * segments_directions[segment_id]
         boundaries_positions.append(position)
 

--- a/morph_tool/plot/dendrogram.py
+++ b/morph_tool/plot/dendrogram.py
@@ -88,12 +88,13 @@ def _position_synapses(positions, synapses, neuron_node_id):
         neuron_node_id: neuron's node id from which dendrogram has been built
     """
 
-    def _jitter_x(grp):
+    def jitter_x(grp):
         if len(grp) > 1:
             min_x = grp['x'].min()
             jittered_x = np.arange(0, len(grp), 1) + min_x
             grp.loc[:, 'x'] = jittered_x
         return grp
+
 
     for dendrogram, position in positions.items():
         post_section = ((synapses[POST_SECTION_ID] == dendrogram.section_id)
@@ -109,12 +110,12 @@ def _position_synapses(positions, synapses, neuron_node_id):
 
         # jitter too close synapses
         df = synapses.loc[pre_section | post_section]
+        group_func = lambda idx: round(df.loc[idx, 'y'])
         if len(df) > 1:
-            # pylint: disable=cell-var-from-loop
             # group by Y coordinate and jitter by X coordinate
-            synapses.loc[pre_section | post_section] = df \
-                .groupby(lambda idx: round(df.loc[idx, 'y'])) \
-                .apply(_jitter_x)
+            groups = df.groupby(group_func, group_keys=False)
+            jittered_df = groups.apply(jitter_x)
+            synapses.loc[pre_section | post_section] = jittered_df
 
 
 def _add_neurite_legend(fig, dendrogram):

--- a/morph_tool/plot/dendrogram.py
+++ b/morph_tool/plot/dendrogram.py
@@ -1,4 +1,6 @@
 """Module for drawing dendrograms with synapses."""
+from functools import partial
+
 import numpy as np
 from neurom import NeuriteType
 from neurom.core import Neurite, Morphology
@@ -50,10 +52,7 @@ def _draw_line(start, end, color):
     return graph_objects.layout.Shape(
         type="line", xref="x", yref="y", x0=start[0], y0=start[1], x1=end[0], y1=end[1],
         opacity=0.4,
-        line=dict(
-            color=color,
-            width=2,
-        ),
+        line={"color": color, "width": 2},
     )
 
 
@@ -95,6 +94,8 @@ def _position_synapses(positions, synapses, neuron_node_id):
             grp.loc[:, 'x'] = jittered_x
         return grp
 
+    def group_y(idx, df):
+        return round(df.loc[idx, 'y'])
 
     for dendrogram, position in positions.items():
         post_section = ((synapses[POST_SECTION_ID] == dendrogram.section_id)
@@ -110,10 +111,9 @@ def _position_synapses(positions, synapses, neuron_node_id):
 
         # jitter too close synapses
         df = synapses.loc[pre_section | post_section]
-        group_func = lambda idx: round(df.loc[idx, 'y'])
         if len(df) > 1:
             # group by Y coordinate and jitter by X coordinate
-            groups = df.groupby(group_func, group_keys=False)
+            groups = df.groupby(partial(group_y, df=df), group_keys=False)
             jittered_df = groups.apply(jitter_x)
             synapses.loc[pre_section | post_section] = jittered_df
 

--- a/morph_tool/transform.py
+++ b/morph_tool/transform.py
@@ -160,7 +160,7 @@ def _get_points(morph, method, neurite_type, target_point):
                 elif neurite_type == 'apical':
                     target_secid = apical_point_section_segment(morph)[0]
                 else:
-                    raise Exception(f"We don't know how to get target point for {neurite_type}.")
+                    raise RuntimeError(f"We don't know how to get target point for {neurite_type}.")
 
                 return np.vstack(
                     [section.points

--- a/tox.ini
+++ b/tox.ini
@@ -25,7 +25,7 @@ commands =
     rm -rf {toxinidir}/dist
     python setup.py sdist bdist_wheel
     twine check {toxinidir}/dist/*
-whitelist_externals = rm
+allowlist_externals = rm
 
 [testenv:lint]
 deps =
@@ -58,7 +58,7 @@ changedir = doc
 extras = docs
 # make warnings into errors with -W sphinx option
 commands = make html SPHINXOPTS=-W
-whitelist_externals = make
+allowlist_externals = make
 
 # E731: do not assign a lambda expression, use a def
 # W503: line break after binary operator


### PR DESCRIPTION
Fixes error due to the adding of the group as an index to the jittered dataframe.
```python
E       ValueError: operands could not be broadcast together with shapes (5,2) (3,) (5,2)
```
