### PR TITLE
Fix converter.from_swc

### DIFF
--- a/morph_tool/converter.py
+++ b/morph_tool/converter.py
@@ -216,8 +216,7 @@ def from_swc(neuron, output_ext):
     elif neuron.soma_type == SomaType.SOMA_NEUROMORPHO_THREE_POINT_CYLINDERS:
         cylinder_to_cylindrical_contour(neuron)
     elif neuron.soma_type == SomaType.SOMA_SINGLE_POINT:
-        if output_ext == 'asc':
-            single_point_sphere_to_circular_contour(neuron)
+        single_point_sphere_to_circular_contour(neuron)
     else:
         raise MorphToolException(
             f'A SWC morphology is not supposed to have a soma of type: {neuron.soma_type}')

--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,11 @@ testdeps =
     bluepysnap>=0.5
     pandas
 
+[pytest]
+minversion = 6.0
+testpaths =
+    tests
+
 [tox]
 envlist =
     {py38,py39,py310,py311}
@@ -17,7 +22,7 @@ envlist =
 [testenv]
 extras = all
 deps = {[base]testdeps}
-commands = pytest --basetemp={envtmpdir} tests {posargs}
+commands = pytest --basetemp={envtmpdir} {posargs}
 
 [testenv:check-dist]
 deps = twine


### PR DESCRIPTION
This PR depends on #122 

### Context

*.h5 file should also convert `SOMA_SINGLE_POINT` into `SOMA_SIMPLE_CONTOUR` (required by `MorphIO==3.3.7`). 

### Resolution

Call `single_point_sphere_to_circular_contour()` also for h5 files.