### PR TITLE
Feat: Ensure area is same as nrn for point swc soma

### DIFF
--- a/morph_tool/cli.py
+++ b/morph_tool/cli.py
@@ -63,22 +63,35 @@ def convert():
               help='whether to traverse the neuron in the NEURON fashion')
 @click.option('--single-point-soma', is_flag=True, help='For SWC files only')
 @click.option('--sanitize', is_flag=True, help='whether to sanitize the morphology')
-def file(input_file, output_file, quiet, recenter, nrn_order, single_point_soma, sanitize):
+@click.option('--ensure-NRN-area', is_flag=True,
+              help='whether to ensure area is preserved in NEURON from swc point soma')
+def file(input_file,
+         output_file,
+         quiet,
+         recenter,
+         nrn_order,
+         single_point_soma,
+         sanitize,
+         ensure_NRN_area):
     """Convert a single morphology from/to the following formats: ASC, SWC, H5."""
     if quiet:
         L.setLevel(logging.WARNING)
 
-    converter.convert(input_file, output_file, recenter, nrn_order, single_point_soma, sanitize)
+    converter.convert(
+        input_file, output_file, recenter, nrn_order, single_point_soma, sanitize, ensure_NRN_area
+    )
 
 
-def _attempt_convert(path, output_dir, extension, recenter, nrn_order, single_point_soma, sanitize):
+def _attempt_convert(
+    path, output_dir, extension, recenter, nrn_order, single_point_soma, sanitize, ensure_NRN_area
+):
     """Function to be passed to dask.bag.map.
 
     Attempts a conversion and returns the path if it failed
     """
     try:
         converter.convert(path, Path(output_dir) / (path.stem + '.' + extension),
-                          recenter, nrn_order, single_point_soma, sanitize)
+                          recenter, nrn_order, single_point_soma, sanitize, ensure_NRN_area)
         return None
     except:  # noqa, pylint: disable=bare-except
         return str(path)
@@ -97,6 +110,8 @@ def _attempt_convert(path, output_dir, extension, recenter, nrn_order, single_po
 @click.option('--single-point-soma', is_flag=True,
               help='For SWC files only')
 @click.option('--sanitize', is_flag=True, help='whether to sanitize the morphologies')
+@click.option('--ensure-NRN-area', is_flag=True,
+              help='whether to ensure area is preserved in NEURON from swc point soma')
 @click.option('--ncores', help='The number of cores', default=None, type=int)
 def folder(input_dir,  # pylint: disable=too-many-arguments
            output_dir,
@@ -106,6 +121,7 @@ def folder(input_dir,  # pylint: disable=too-many-arguments
            nrn_order,
            single_point_soma,
            sanitize,
+           ensure_NRN_area,
            ncores):
     """Convert all morphologies in the folder and its subfolders."""
     # pylint: disable=import-outside-toplevel
@@ -127,7 +143,8 @@ def folder(input_dir,  # pylint: disable=too-many-arguments
         recenter=recenter,
         nrn_order=nrn_order,
         single_point_soma=single_point_soma,
-        sanitize=sanitize)
+        sanitize=sanitize,
+        ensure_NRN_area=ensure_NRN_area)
     failed_conversions = list(filter(None, failed_conversions))
 
     if failed_conversions:

--- a/morph_tool/cli.py
+++ b/morph_tool/cli.py
@@ -72,18 +72,18 @@ def file(input_file,
          nrn_order,
          single_point_soma,
          sanitize,
-         ensure_NRN_area):
+         ensure_nrn_area):
     """Convert a single morphology from/to the following formats: ASC, SWC, H5."""
     if quiet:
         L.setLevel(logging.WARNING)
 
     converter.convert(
-        input_file, output_file, recenter, nrn_order, single_point_soma, sanitize, ensure_NRN_area
+        input_file, output_file, recenter, nrn_order, single_point_soma, sanitize, ensure_nrn_area
     )
 
 
 def _attempt_convert(
-    path, output_dir, extension, recenter, nrn_order, single_point_soma, sanitize, ensure_NRN_area
+    path, output_dir, extension, recenter, nrn_order, single_point_soma, sanitize, ensure_nrn_area
 ):
     """Function to be passed to dask.bag.map.
 
@@ -91,7 +91,7 @@ def _attempt_convert(
     """
     try:
         converter.convert(path, Path(output_dir) / (path.stem + '.' + extension),
-                          recenter, nrn_order, single_point_soma, sanitize, ensure_NRN_area)
+                          recenter, nrn_order, single_point_soma, sanitize, ensure_nrn_area)
         return None
     except:  # noqa, pylint: disable=bare-except
         return str(path)
@@ -121,7 +121,7 @@ def folder(input_dir,  # pylint: disable=too-many-arguments
            nrn_order,
            single_point_soma,
            sanitize,
-           ensure_NRN_area,
+           ensure_nrn_area,
            ncores):
     """Convert all morphologies in the folder and its subfolders."""
     # pylint: disable=import-outside-toplevel
@@ -144,7 +144,7 @@ def folder(input_dir,  # pylint: disable=too-many-arguments
         nrn_order=nrn_order,
         single_point_soma=single_point_soma,
         sanitize=sanitize,
-        ensure_NRN_area=ensure_NRN_area)
+        ensure_nrn_area=ensure_nrn_area)
     failed_conversions = list(filter(None, failed_conversions))
 
     if failed_conversions:

--- a/morph_tool/converter.py
+++ b/morph_tool/converter.py
@@ -183,6 +183,7 @@ def single_point_sphere_to_circular_contour(neuron, ensure_NRN_area=True):
 
         from morph_tool.neuron_surface import get_NEURON_surface
         from scipy.optimize import minimize_scalar
+        import shutil
 
         def cost(radius):
             make_soma(radius)
@@ -193,6 +194,7 @@ def single_point_sphere_to_circular_contour(neuron, ensure_NRN_area=True):
             cost, bounds=(0.8 * swc_radius, 1.2 * swc_radius), options={"xatol": 1e-2}
         ).x
         make_soma(radius)
+        shutil.remove("tmp.asc")
 
 
 def soma_to_single_point(soma):

--- a/morph_tool/converter.py
+++ b/morph_tool/converter.py
@@ -159,7 +159,7 @@ def cylinder_to_cylindrical_contour(neuron):
     neuron.soma.type = SomaType.SOMA_SIMPLE_CONTOUR
 
 
-def single_point_sphere_to_circular_contour(neuron, ensure_NRN_area=True):
+def single_point_sphere_to_circular_contour(neuron, ensure_NRN_area=False):
     """Single point soma to contour soma.
 
     Transform a single point soma that represents a sphere into a circular contour that represents
@@ -216,7 +216,7 @@ def soma_to_single_point(soma):
     soma.type = SomaType.SOMA_SINGLE_POINT
 
 
-def from_swc(neuron, output_ext):
+def from_swc(neuron, output_ext, ensure_NRN_area=False):
     """Convert to SWC."""
     if output_ext == 'swc':
         return neuron
@@ -255,7 +255,7 @@ def from_swc(neuron, output_ext):
     elif neuron.soma_type == SomaType.SOMA_NEUROMORPHO_THREE_POINT_CYLINDERS:
         cylinder_to_cylindrical_contour(neuron)
     elif neuron.soma_type == SomaType.SOMA_SINGLE_POINT:
-        single_point_sphere_to_circular_contour(neuron)
+        single_point_sphere_to_circular_contour(neuron, ensure_NRN_area=ensure_NRN_area)
     else:
         raise MorphToolException(
             f'A SWC morphology is not supposed to have a soma of type: {neuron.soma_type}')
@@ -263,11 +263,11 @@ def from_swc(neuron, output_ext):
     return neuron
 
 
-def from_h5_or_asc(neuron, output_ext):
+def from_h5_or_asc(neuron, output_ext, ensure_NRN_area=False):
     """Convert from ASC/H5."""
     if neuron.soma_type == SomaType.SOMA_SINGLE_POINT:
         if output_ext == 'asc':
-            single_point_sphere_to_circular_contour(neuron)
+            single_point_sphere_to_circular_contour(neuron, ensure_NRN_area=ensure_NRN_area)
     elif neuron.soma_type == SomaType.SOMA_SIMPLE_CONTOUR:
         if output_ext == 'swc':
             mean, new_xyz = contourcenter(neuron.soma.points)
@@ -287,7 +287,8 @@ def convert(input_file,
             recenter=False,
             nrn_order=False,
             single_point_soma=False,
-            sanitize=False):
+            sanitize=False,
+            ensure_NRN_area=False):
     """Run the appropriate converter.
 
     Args:
@@ -327,7 +328,7 @@ def convert(input_file,
             f'No converter for morphology type: {neuron.version}') from e
 
     L.info('Original soma type: %s', neuron.soma_type)
-    new = converter(neuron, output_ext)
+    new = converter(neuron, output_ext, ensure_NRN_area=ensure_NRN_area)
 
     if single_point_soma:
         soma_to_single_point(new.soma)

--- a/morph_tool/converter.py
+++ b/morph_tool/converter.py
@@ -13,7 +13,6 @@ from neurom import morphmath
 
 from morph_tool import transform
 from morph_tool.exceptions import MorphToolException
-from morph_tool.neuron_surface import get_NEURON_surface
 
 L = logging.getLogger(__name__)
 
@@ -184,6 +183,10 @@ def single_point_sphere_to_circular_contour(neuron, ensure_NRN_area=False):
     make_soma(swc_radius)
 
     if ensure_NRN_area:
+
+        # pylint: disable=import-outside-toplevel
+        from morph_tool.neuron_surface import get_NEURON_surface
+
         surf = 4.0 * np.pi * swc_radius**2
         filename = f"{str(uuid.uuid4())}.asc"
 
@@ -197,7 +200,7 @@ def single_point_sphere_to_circular_contour(neuron, ensure_NRN_area=False):
                 cost, bounds=(0.8 * swc_radius, 1.2 * swc_radius), options={"xatol": 1e-2}
             ).x
             make_soma(radius)
-        except Exception:
+        except Exception:  # pylint: disable=broad-exception-caught
             L.warning("Could not find a suitable radius, we use the original radius")
             make_soma(swc_radius)
         finally:
@@ -299,6 +302,7 @@ def convert(input_file,
         nrn_order(bool): whether to traverse the neuron in the NEURON fashion
         single_point_soma(bool): For SWC only
         sanitize(bool): whether to sanitize the morphology
+        ensure_NRN_area(bool): to ensure area is preserved in NEURON from swc point soma
     """
     kwargs = {}
     if nrn_order:

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ base_extras = [
     'numpy>=1.14',
     'pandas>=1.0.3',
     'xmltodict>=0.12.0',
+    'scipy>=1.2.0',
 ]
 plot_extras = ['plotly>=4.1.0']
 parallel_extras = ['dask[bag]>=2.19.0']

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -10,6 +10,7 @@ from morph_tool import converter
 from morph_tool import diff
 from morph_tool.exceptions import MorphToolException
 from morph_tool.converter import convert
+from morph_tool.neuron_surface import get_NEURON_surface
 
 DATA = Path(__file__).parent / 'data'
 
@@ -31,6 +32,18 @@ def test_convert(tmpdir):
         convert(inname, outname)
         diff_result = diff(inname, outname, rtol=1e-5, atol=1e-5)
         assert not bool(diff_result), diff_result.info
+
+
+def test_convert_ensure_NRN_area(tmpdir):
+    simple = DATA / 'simple.swc'
+    outname = Path(tmpdir, 'test.asc')
+    convert(simple, outname, ensure_NRN_area=False)
+
+    npt.assert_almost_equal(get_NEURON_surface(simple), 12.5663, decimal=4)
+    npt.assert_almost_equal(get_NEURON_surface(outname), 11.9835, decimal=4)
+
+    convert(simple, outname, ensure_NRN_area=True)
+    npt.assert_almost_equal(get_NEURON_surface(outname), 12.59102, decimal=4)
 
 
 def test_convert_recenter(tmpdir):


### PR DESCRIPTION
### Context

For emodel, if we convert swc to asc, neuron does not read the same soma surface area, hence the model behave differently.

### Resolution

It is quite hard to find a correction factor from asc loader (swc is just area = 4 *pi * R^2), hence we do a simple optimisation.
