### PR TITLE
Can get all differences between 2 morphs instead of only the first one

### DIFF
--- a/morph_tool/morphio_diff.py
+++ b/morph_tool/morphio_diff.py
@@ -50,6 +50,9 @@ def diff(morph1, morph2, rtol=1.e-5, atol=1.e-8, *, skip_perimeters=False, all_d
         skip_perimeters (bool): do not check the perimeters if set to True
         all_diffs (bool): return all differences if set to True
     """
+    # pylint: disable=too-many-branches
+    # pylint: disable=too-many-locals
+    # pylint: disable=too-many-return-statements
     if not isinstance(morph1, Morphology):
         morph1 = Morphology(morph1)
     if not isinstance(morph2, Morphology):
@@ -107,5 +110,4 @@ def diff(morph1, morph2, rtol=1.e-5, atol=1.e-8, *, skip_perimeters=False, all_d
 
     if all_diffs and len(diffs) > 0:
         return DiffResult(True, "\n\n".join(diffs))
-    else:
-        return DiffResult(False)
+    return DiffResult(False)

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -20,12 +20,14 @@ def test_equality():
         '''Not a root section, not a leaf section'''
         return neuron.root_sections[0].children[0]
 
+    # Report different section types
     a = Morphology(DATA / 'simple2.asc')
     mundane_section(a).type = SectionType.apical_dendrite
     result = diff(neuron_ref, a)
     assert result
     assert result.info == 'Section(id=1, points=[(0 5 0),..., (-6 5 0)]) and Section(id=1, points=[(0 5 0),..., (-6 5 0)]) have different section types'
 
+    # Report different section points
     a = Morphology(DATA / 'simple2.asc')
     mundane_section(a).points = [[0,0,0], [0,0,0], [0,0,1]]
     result = diff(neuron_ref, a)
@@ -37,6 +39,7 @@ def test_equality():
                             'have the same shape but different values',
                             'Vector points differs at index 0: [0. 5. 0.] != [0. 0. 0.]']))
 
+    # Report different section diameters
     a = Morphology(DATA / 'simple2.asc')
     mundane_section(a).diameters = [0,0,0]
     result = diff(neuron_ref, a)
@@ -48,6 +51,7 @@ def test_equality():
                             'have the same shape but different values',
                             'Vector diameters differs at index 0: 3.0 != 0.0']))
 
+    # Report different section perimeters
     a = Morphology(DATA / 'simple2.asc')
     for section in a.iter():
         section.perimeters = [1] * len(section.points)
@@ -60,18 +64,61 @@ def test_equality():
                             'have different shapes: (0,) vs (2,)']))
 
 
+    # Report different number of children
     a = Morphology(DATA / 'simple2.asc')
     mundane_section(a).append_section(PointLevel([[-6, 5, 0], [4, 5, 6]], [2, 3]))
     result = diff(neuron_ref, a)
     assert result
     assert result.info == 'Section(id=1, points=[(0 5 0),..., (-6 5 0)]) and Section(id=1, points=[(0 5 0),..., (-6 5 0)]) have a different number of children'
 
+    # Report different number of root sections
     a = Morphology(DATA / 'simple2.asc')
     a.delete_section(a.root_sections[0])
     result = diff(neuron_ref, a)
     assert result
     assert result.info == 'Both morphologies have a different number of root sections'
 
+    # Report only different number of root sections even though diameters are also different
+    a = Morphology(DATA / 'simple2.asc')
+    mundane_section(a).diameters = [0,0,0]
+    a.delete_section(a.root_sections[1])
+    result = diff(neuron_ref, a, all_diffs=True)
+    assert result
+    assert result.info == 'Both morphologies have a different number of root sections'
+
+    # Report only different section points but not the different section diameters
+    a = Morphology(DATA / 'simple2.asc')
+    mundane_section(a).points = [[0,0,0], [0,0,0], [0,0,1]]
+    mundane_section(a).diameters = [0,0,0]
+    result = diff(neuron_ref, a, all_diffs=False)
+    assert result
+    assert (result.info ==
+                 '\n'.join(['Attributes Section.points of:',
+                            'Section(id=1, points=[(0 5 0),..., (-6 5 0)])',
+                            'Section(id=1, points=[(0 0 0),..., (0 0 1)])',
+                            'have the same shape but different values',
+                            'Vector points differs at index 0: [0. 5. 0.] != [0. 0. 0.]']))
+
+    # Report both different section points and different section diameters
+    a = Morphology(DATA / 'simple2.asc')
+    mundane_section(a).points = [[0,0,0], [0,0,0], [0,0,1]]
+    mundane_section(a).diameters = [0,0,0]
+    result = diff(neuron_ref, a, all_diffs=True)
+    assert result
+    assert (result.info ==
+                 '\n'.join(['Attributes Section.points of:',
+                            'Section(id=1, points=[(0 5 0),..., (-6 5 0)])',
+                            'Section(id=1, points=[(0 0 0),..., (0 0 1)])',
+                            'have the same shape but different values',
+                            'Vector points differs at index 0: [0. 5. 0.] != [0. 0. 0.]',
+                            '',
+                            'Attributes Section.diameters of:',
+                            'Section(id=1, points=[(0 5 0),..., (-6 5 0)])',
+                            'Section(id=1, points=[(0 0 0),..., (0 0 1)])',
+                            'have the same shape but different values',
+                            'Vector diameters differs at index 0: 3.0 != 0.0']))
+
+    # Check result for MorphIO < 3
     result = diff(DATA / 'single_child.asc', DATA / 'not_single_child.asc')
     if parse_version(get_distribution("morphio").version) < parse_version("3"):
         assert not result


### PR DESCRIPTION
### Context

The `morph_tool.morphio_diff.diff()` function returns only the first difference found between the 2 given morphologies. In some cases it can be more convenient to get all errors at once.

### Resolution

Collect all errors and create a `DiffResult` object that joins all error descriptions.